### PR TITLE
Force escape char interpretation for install script echos.

### DIFF
--- a/bin/install-go.sh
+++ b/bin/install-go.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+function echo() { builtin echo -e "$@"; }
+
 function run_installer()
 {
 	####### Init vars


### PR DESCRIPTION
I get this when running the install script on a fresh ubuntu 14.04 instance:

```
Found all dependencies (0/0)

==> This script will install:
==> Ethereum:\n ➜  /usr/bin/geth\n

==> Before installing Geth (ethereum CLI) read this:
```