### PR TITLE
fix for boxen

### DIFF
--- a/bin/install-cpp.sh
+++ b/bin/install-cpp.sh
@@ -4,8 +4,8 @@ function run_installer()
 {
 	####### Init vars
 
-	HOMEBREW_PREFIX=/usr/local
-	HOMEBREW_CACHE=/Library/Caches/Homebrew
+	HOMEBREW_PREFIX=`brew --prefix`
+	HOMEBREW_CACHE=`brew --cache`
 	HOMEBREW_REPO=https://github.com/Homebrew/homebrew
 	OSX_REQUIERED_VERSION="10.7.0"
 


### PR DESCRIPTION
I use boxen so after running this script, I get the following:

```
$ eth --help
dyld: Library not loaded: /usr/local/lib/libboost_system.dylib
  Referenced from: /usr/local/bin/eth
  Reason: image not found
[1]    70869 trace trap  eth --help
```

libboost isn't in /usr/local. mine is in:

```
$ brew list boost | grep libboost_system.dylib
/opt/boxen/homebrew/Cellar/boost/1.59.0/lib/libboost_system.dylib
```

anyway, this change will correctly set the cache and install dirs.