### PR TITLE
Avoiding horizontal scrolling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,5 +1,5 @@
 html {
-	overflow: scroll;
+	overflow: auto;
 }
 
 body {


### PR DESCRIPTION
The website currently shows a horizontal scroll when you're using browsers in OS X. This behavior is caused by this `overflow: scroll;` rule 0 which in fact doesn't make sense in this context. Changing it to `auto` shows the scroll bars only if needed.

![captura de tela 2016-02-01 21 18 39](https://cloud.githubusercontent.com/assets/673884/12735800/7335d94e-c929-11e5-9c2d-29ad7147fc71.png)
