### PR TITLE
Fix typos, remove duplicate directions and project list entry

### DIFF
--- a/views/content/cli.md
+++ b/views/content/cli.md
@@ -45,11 +45,10 @@ The **Go** implementation is called **Geth** (the Old English third person singu
 
 ### Install: Mac and Linux
 
-In order to 'geth' it, open your command line tool (if you are unsure how to do this, consider waiting for a more user friendly release) paste the above one-liner in your terminal for an automated install script. This script will detect your OS and will attempt to install Geth. 
+In order to 'geth' it, open your command line tool (if you are unsure how to do this, consider waiting for a more user friendly release) and paste the following one-liner in your terminal for an automated install script. This script will detect your OS and will attempt to install Geth:
 
     bash <(curl https://install-geth.ethereum.org -L)
 
-Paste the above one-liner in your terminal for an automated install script. This script will detect your OS and will attempt to install the ethereum CLI. 
 
 ### Windows
 

--- a/views/content/cli.md
+++ b/views/content/cli.md
@@ -40,7 +40,7 @@ Open the [command prompt](http://windows.microsoft.com/en-us/windows-vista/open-
 
 ![Logo for Go](/images/icons/gopher.png)
 
-The **Go** implementation is called **Geth** (the old english third person singular conjugation of “to go”. Quite appropriate given geth is written in Go). Geth has been audited for security and will be the future basis for the end user facing **Mist Browser**, so if you have experience on web development and are interested in building frontend for html dapps, you should experiment with Geth.
+The **Go** implementation is called **Geth** (the Old English third person singular conjugation of “to go”. Quite appropriate given geth is written in Go). Geth has been audited for security and will be the future basis for the end user facing **Mist Browser**, so if you have experience on web development and are interested in building frontend for html dapps, you should experiment with Geth.
 
 
 ### Install: Mac and Linux
@@ -76,7 +76,7 @@ The **Python** implementation is called Pyethapp. If you are interested in under
 
 ### Run it
 
-Geth and Eth are multipurpose command line tools that runs a full Ethereum node implemented in Go. They offer multiple interfaces: the [command line](http://guide.ethereum.org/cli.html) subcommands and options, a [JSON-RPC server](http://guide.ethereum.org/rpc.html) and an [interactive console](http://guide.ethereum.org/jsre.html).
+Geth and Eth are multipurpose command line tools that run a full Ethereum node implemented in Go. They offer multiple interfaces: the [command line](http://guide.ethereum.org/cli.html) subcommands and options, a [JSON-RPC server](http://guide.ethereum.org/rpc.html) and an [interactive console](http://guide.ethereum.org/jsre.html).
 
 For the purposes of this guide, we will focus on the Console, a JavaScript environment that contains all the main features you probably want. Depending on your client, paste either of these commands:
 
@@ -88,14 +88,14 @@ For the purposes of this guide, we will focus on the Console, a JavaScript envir
 
     eth --frontier -b -i  
 
-The first time you start the command line you will be presented with a license. Before you can use them, you **must** accept this license, please read it careful.
+The first time you start the command line you will be presented with a license. Before you can use them, you **must** accept this license, please read it carefully.
 
 **ATTENTION: If you just want to test the technology and play around, DON'T USE THE MAIN NETWORK. Read further to find out how to deploy a private test network without spending your ether.**
 
 
 ### Connecting to a private test net
 
-Sometimes you might not want to connect to the live public network; Instead you can choose to create your own private testnet. This is very useful if you don't need to test public contracts and want just to try- or develop on the technology. Since you are the only member of your private network you are responsible for finding all blocks, validating all transactions and executing all smart contracts. This makes development cheaper and easier as you have the ability to flexibly control the inclusion of transactions in your own personal blockchain.
+Sometimes you might not want to connect to the live public network; instead you can choose to create your own private testnet. This is very useful if you don't need to test public contracts and want just to try- or develop on the technology. Since you are the only member of your private network you are responsible for finding all blocks, validating all transactions and executing all smart contracts. This makes development cheaper and easier as you have the ability to flexibly control the inclusion of transactions in your own personal blockchain.
 
 **Geth:**
 
@@ -107,8 +107,7 @@ Sometimes you might not want to connect to the live public network; Instead you 
 
 Replace 12345 with any random number you want to use as the network ID. It's a good idea to change the content of the genesis block because if someone accidentally connects to your testnet using the real chain, your local copy will be considered a stale fork and updated to the _"real"_ one. Changing the datadir also changes your local copy of the blockchain, otherwise, in order to successfully mine a block, you would need to mine against the difficulty of the last block present in your local copy of the blockchain - which may take several hours. 
 
-If you want to create a private network you should, for security reasons, use a different genesis block (a database that contains all the transactions from the Ether sales). You can 
-[Read our announcement blog post on how to generate your file](https://blog.ethereum.org/2015/07/27/final-steps/). In the near future we will provide better ways to get other genesis blocks.
+If you want to create a private network you should, for security reasons, use a different genesis block (a database that contains all the transactions from the Ether sales). You can [read our announcement blog post on how to generate your file](https://blog.ethereum.org/2015/07/27/final-steps/). In the near future we will provide better ways to get other genesis blocks.
 
 These commands prevent anyone who doesn't know your chosen — secret — nonce, network id and genesis file, from connecting to you or providing you with unwanted data. If you *want* to connect to other peers and create a small private network of multiple computers they will all need to use the same networkid and an identical genesis block. You will also have to help each node find the others. To do that, first you need your own Node URL:
 
@@ -159,7 +158,7 @@ In order to do anything on an Ethereum network you need ether, and to get it, yo
 
     web3.admin.eth.newAccount({name:"account01",password:"Write here a good, randomly generated, passphrase!", passwordHint:"my hint"})
 
-**Note: Pick up a good passphrase and write it down. If you lose the passphrase you used to encrypt your account, you will not be able to access that account. Repeat: There are no safety nets. It is NOT possible to access your account without a valid passphrase and there is no "forgot my password" option here. See [this XKCD](https://xkcd.com/936/) for details**
+**Note: Pick up a good passphrase and write it down. If you lose the passphrase you used to encrypt your account, you will not be able to access that account. Repeat: There are no safety nets. It is NOT possible to access your account without a valid passphrase and there is no "forgot my password" option here. See [this XKCD](https://xkcd.com/936/) for details.**
 
 Password hint is optional. You can pick any name you want, it isn't very important.
 

--- a/views/content/crowdsale.md
+++ b/views/content/crowdsale.md
@@ -2,13 +2,13 @@
 
 # Crowdfund your idea
 
-Sometimes a good idea takes a lot of funds and collective effort. You could ask for donations, but donors prefer to give to projects they are more certain that will get traction and proper funding. This is an example where a crowdfunding would be ideal: you set up a goal and a deadline for reaching it. If you miss your goal, the donations are returned, therefore reducing the risk for donors. Since the code is open and auditable, there is no need for a centralized trusted platform and therefore the only fees everyone will pay are just the gas fees.
+Sometimes a good idea takes a lot of funds and collective effort. You could ask for donations, but donors prefer to give to projects they are more certain will get traction and proper funding. This is an example where a crowdfunding would be ideal: you set up a goal and a deadline for reaching it. If you miss your goal, the donations are returned, therefore reducing the risk for donors. Since the code is open and auditable, there is no need for a centralized, trusted platform and therefore the only fees everyone will pay are just the gas fees.
 
 In a crowdfunding prizes are usually given. This would require you to get everyone's contact information and keep track of who owns what. But since you just created your own token, why not use that to keep track of the prizes? This allows donors to immediately own something after they donated. They can store it safely, but they can also sell or trade it if they realize they don't want the prize anymore. If your idea is something physical, all you have to do after the project is completed is to give the product to everyone who sends you back a token. If the project is digital the token itself can immediately be used for users to participate or get entry on your project.
 
 ### The code
 
-The way this particular crowdsale contract works is that you set an exchange rate for your token and then the donors will immediately get a proportional amount of tokens in exchange of their ether. You will also choose a funding goal and a deadline: once that deadline is over you can ping the contract and if the goal was reached it will send the ether raised to you, otherwise it goes back to the donors. Donors keep their tokens even if the project doesn't reach its goal, as a proof that they helped.
+The way this particular crowdsale contract works is that you set an exchange rate for your token and then the donors will immediately get a proportional amount of tokens in exchange for their ether. You will also choose a funding goal and a deadline: once that deadline is over you can ping the contract and if the goal was reached it will send the ether raised to you, otherwise it goes back to the donors. Donors keep their tokens even if the project doesn't reach its goal, as a proof that they helped.
     
     
     contract token { mapping (address => uint) public coinBalanceOf; function token() {}  function sendCoin(address receiver, uint amount) returns(bool sufficient) {  } }
@@ -197,7 +197,7 @@ Now wait a minute for the blocks to pickup and you can check if the contract rec
 
 ### Recover funds
 
-Once the deadline is passed someone has to wake up the contract to have the funds sent to either the beneficiary or back to the funders (if it failed). This happens because there is no such thing as an active loop or timer on ethereum so any future transactions must be pinged by someone.
+Once the deadline has passed someone has to wake up the contract to have the funds sent to either the beneficiary or back to the funders (if it failed). This happens because there is no such thing as an active loop or timer on ethereum so any future transactions must be pinged by someone.
 
     crowdsale.checkGoalReached.sendTransaction({from:eth.accounts[0], gas: 2000000})
 
@@ -212,7 +212,7 @@ The crowdsale instance is setup to self destruct once it has done its job, so if
 
     eth.getCode(crowdsale.address)
 
-So you raised a 100 ethers and successfully distributed your original coin among the crowdsale donors. What could you do next with those things?
+So you raised 100 ethers and successfully distributed your original coin among the crowdsale donors. What could you do next with those things?
 
 
 

--- a/views/content/dao.md
+++ b/views/content/dao.md
@@ -4,13 +4,13 @@
 
 
 
-So far you have created a tradeable token and you successfully distributed it among all those who were willing to help fundraise a 100 ethers. That's all very interesting but what exactly are those tokens for?  Why would anyone want to own or trade it for anything else valuable? If you can convince your new token is the next big money maybe others will want it, but so far your token offers no value per se. We are going to change that, by creating your first decentralized autonomous organization, or DAO.
+So far you have created a tradeable token and you successfully distributed it among all those who were willing to help fundraise 100 ethers. That's all very interesting but what exactly are those tokens for?  Why would anyone want to own or trade it for anything else valuable? If you can convince others that your new token is the next big money maybe they will want it, but so far your token offers no value per se. We are going to change that, by creating your first decentralized autonomous organization, or DAO.
 
 Think of the DAO as the constitution of a country, the executive branch of a government or maybe like a  robotic manager for an organization. The DAO receives the money that your organization raises, keeps it safe and uses it to fund whatever its members want. The robot is incorruptible, will never defraud the bank, never create secret plans, never use the money for anything other than what its constituents voted on. The DAO will never disappear, never run away and cannot be controlled by anyone other than its own citizens.
 
 The token we distributed using the crowdsale is the only citizen document needed. Anyone who holds any token is able to create and vote on proposals. Similar to being a shareholder in a company, the token can be traded on the open market and the vote is proportional to amounts of tokens the voter holds.  
 
-Take a moment to dream about the revolutionary possibilities this would allow, and now you can do it yourself, in under a 100 lines of code:
+Take a moment to dream about the revolutionary possibilities this would allow, and now you can do it yourself, in under 100 lines of code:
 
 
 ### The Code
@@ -125,7 +125,7 @@ So open your console and let's get ready to finally put your country online. Fir
     var _minimumQuorum = 10; // Minimum amount of voter tokens the proposal needs to pass
     var _debatingPeriod = 60; // debating period, in minutes;
 
-With these default parameters anyone with any tokens can make a proposal on how to spend the organization's money. The proposal has 1 hour to be debated and it will pass if it has at least votes from at least 0.1% of the total tokens and has more support than rejections. Pick those parameters with care, as you won't be able to change them in the future.
+With these default parameters anyone with any tokens can make a proposal on how to spend the organization's money. The proposal has 1 hour to be debated and it will pass if it has votes from at least 0.1% of the total tokens and has more support than rejections. Pick those parameters with care, as you won't be able to change them in the future.
     
     var daoCompiled = eth.compile.solidity('contract token { mapping (address => uint) public coinBalanceOf; function token() { } function sendCoin(address receiver, uint amount) returns(bool sufficient) { } } contract Democracy { uint public minimumQuorum; uint public debatingPeriod; token public voterShare; address public founder; Proposal[] public proposals; uint public numProposals; event ProposalAdded(uint proposalID, address recipient, uint amount, bytes32 data, string description); event Voted(uint proposalID, int position, address voter); event ProposalTallied(uint proposalID, int result, uint quorum, bool active); struct Proposal { address recipient; uint amount; bytes32 data; string description; uint creationDate; bool active; Vote[] votes; mapping (address => bool) voted; } struct Vote { int position; address voter; } function Democracy(token _voterShareAddress, uint _minimumQuorum, uint _debatingPeriod) { founder = msg.sender; voterShare = token(_voterShareAddress); minimumQuorum = _minimumQuorum || 10; debatingPeriod = _debatingPeriod * 1 minutes || 30 days; } function newProposal(address _recipient, uint _amount, bytes32 _data, string _description) returns (uint proposalID) { if (voterShare.coinBalanceOf(msg.sender)>0) { proposalID = proposals.length++; Proposal p = proposals[proposalID]; p.recipient = _recipient; p.amount = _amount; p.data = _data; p.description = _description; p.creationDate = now; p.active = true; ProposalAdded(proposalID, _recipient, _amount, _data, _description); numProposals = proposalID+1; } else { return 0; } } function vote(uint _proposalID, int _position) returns (uint voteID){ if (voterShare.coinBalanceOf(msg.sender)>0 && (_position >= -1 || _position <= 1 )) { Proposal p = proposals[_proposalID]; if (p.voted[msg.sender] == true) return; voteID = p.votes.length++; Vote v = p.votes[voteID]; v.position = _position; v.voter = msg.sender; p.voted[msg.sender] = true; Voted(_proposalID, _position, msg.sender); } else { return 0; } } function executeProposal(uint _proposalID) returns (int result) { Proposal p = proposals[_proposalID]; /* Check if debating period is over */ if (now > (p.creationDate + debatingPeriod) && p.active){ uint quorum = 0; /* tally the votes */ for (uint i = 0; i < p.votes.length; ++i) { Vote v = p.votes[i]; uint voteWeight = voterShare.coinBalanceOf(v.voter); quorum += voteWeight; result += int(voteWeight) * v.position; } /* execute result */ if (quorum > minimumQuorum && result > 0 ) { p.recipient.call.value(p.amount)(p.data); p.active = false; } else if (quorum > minimumQuorum && result < 0) { p.active = false; } } ProposalTallied(_proposalID, result, quorum, p.active); } }');
 
@@ -293,10 +293,10 @@ For the sake of simplicity, we only used the democratic organization you created
 
 * Your DAO could own its own name on the name registrar, and then change where it's redirecting in order to update itself if the token holders approved.
 
-* The organization could hold not only ethers, but any kind of other coin created on ethereum, including assets whose value are tied to the bitcoin or dollar. 
+* The organization could hold not only ethers, but any other kind of coin created on ethereum, including assets whose values are tied to the bitcoin or dollar. 
 
 * The DAO could be programmed to allow a proposal with multiple transactions, some scheduled to the future. 
-It could also own shares of other DAO's, meaning it could vote on larger organization or be a part of a federation of DAO's.
+It could also own shares of other DAOs, meaning it could vote on larger organization or be a part of a federation of DAOs.
 
 * The Token Contract could be reprogrammed to hold ether or to hold other tokens and distribute it to the token holders. This would link the value of the token to the value of other assets, so paying dividends could be accomplished by simply moving funds to the token address.
 

--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -48,7 +48,7 @@ To check your earnings, you can display your balance with:
 #### GPU MINING
 
 
-If you are serious about mining on the live ethereum network and get real ether rewards, then you should use a dedicated computer with very powerful graphic cards in order to run the network. 
+If you are serious about mining on the live ethereum network and getting real ether rewards, then you should use a dedicated computer with very powerful graphic cards in order to run the network. 
 
 
 **Instructions for Eth:** 
@@ -67,10 +67,10 @@ There are currently two options for GPU mining in Geth available. You can read a
 
 * **C++ Etherminer**. This is a version for the pro miners. To install it, follow the guide to [install the whole C++ ethereum code](https://github.com/ethereum/cpp-ethereum/wiki/Installing-clients). 
 
-* **Go experimental GPU branch**. It's experimental so you need to build go from source to get it. This version is focused for hobbyists and developers. To install it, [clone geth from source](https://github.com/ethereum/go-ethereum/wiki/Installation-Instructions-for-Ubuntu) and then switch to the [GPU Miner branch](https://github.com/ethereum/go-ethereum/tree/gpu_miner)
+* **Go experimental GPU branch**. It's experimental so you need to build go from source to get it. This version is focused for hobbyists and developers. To install it, [clone geth from source](https://github.com/ethereum/go-ethereum/wiki/Installation-Instructions-for-Ubuntu) and then switch to the [GPU Miner branch](https://github.com/ethereum/go-ethereum/tree/gpu_miner).
 
 
-Both setups are explain in further detail in the [Frontier reference](http://guide.ethereum.org/mining.html)
+Both setups are explained in further detail in the [Frontier reference](http://guide.ethereum.org/mining.html).
 
 #### More information on Mining
 
@@ -80,27 +80,27 @@ Both setups are explain in further detail in the [Frontier reference](http://gui
 
 * Mining prowess roughly scales proportionally to [memory bandwidth](https://en.wikipedia.org/wiki/AMD_Radeon_Rx_200_series#Chipset_table). As our implementation is written in OpenCL, AMD GPUs will be 'faster' than similarly priced NVIDIA GPUs. Empirical evidence has already confirmed this, with R9 290x regularly topping benchmarks. 
 
-* ASICs and FPGAs is be strongly discouraged by being rendered financially inefficient, which was confirmed in [an independent audit](https://github.com/LeastAuthority/ethereum-analyses/blob/master/PoW.md#HardwareFeasibility). Don't expect to see them on the market, and if you do, proceed with extreme caution.
+* ASICs and FPGAs are strongly discouraged by being rendered financially inefficient, which was confirmed in [an independent audit](https://github.com/LeastAuthority/ethereum-analyses/blob/master/PoW.md#HardwareFeasibility). Don't expect to see them on the market, and if you do, proceed with extreme caution.
 
 
 ### 2. Use Bitcoins
 
 ![bitcoin and ethereum](images/bitcoin-and-ethereum-sitting-on-a-tree@2x.png)
 
-Ethereum would never be possible without bitcoin—both the technology and the currency—and we see ourselves not as a competiting currency but as complementary within the digital ecosystem. Ether is to be treated as "crypto-fuel", a token whose purpose is to pay for computation, and is not intended to be used as or considered a currency, asset, share or anything else.
+Ethereum would never be possible without bitcoin—both the technology and the currency—and we see ourselves not as a competing currency but as complementary within the digital ecosystem. Ether is to be treated as "crypto-fuel", a token whose purpose is to pay for computation, and is not intended to be used as or considered a currency, asset, share or anything else.
 
 There are many ways in which you can use Bitcoins within the Ethereum ecosystem:
 
-* **Trade BTC for ETH:** multiple third party companies are working to make the exchanging of ether and bitcoins as easy and seamless as possible. If so desired one could trade a bitcoins for ether with the purpose of executing contracts and trade it back immediately in order to keep their value pegged and secured by the bitcoin network.
+* **Trade BTC for ETH:** multiple third party companies are working to make the exchanging of ether and bitcoins as easy and seamless as possible. If so desired one could trade bitcoins for ether with the purpose of executing contracts and trade it back immediately in order to keep their value pegged and secured by the bitcoin network.
 
-* **Use a pegged derivative:** Ethereum is a great tool for creating complex trading between multiple parties. If you have a source for the price of Bitcoin that all parties trust, then it's possible to create an [ethereum based currency](../token) whose value is pegged to the market value of Bitcoin. This means that you could trade a btc to a token that is guaranteed to always trade back to the same amount of bitcoins while still being fully compatible with other ethereum contracts. There are multiple ways of doing that and as some of these projects go live and are tested by the community, we will list them here.
+* **Use a pegged derivative:** Ethereum is a great tool for creating complex trading between multiple parties. If you have a source for the price of Bitcoin that all parties trust, then it's possible to create an [ethereum based currency](../token) whose value is pegged to the market value of Bitcoin. This means that you could trade bitcoins to a token that is guaranteed to always trade back to the same amount of bitcoins while still being fully compatible with other ethereum contracts. There are multiple ways of doing that and as some of these projects go live and are tested by the community, we will list them here.
 
-* **Use a Bitcoin relay to convert a 2 way peg**: [the bitcoin relay](https://github.com/ethereum/btcrelay/) is a piece of code that allows you to sidechain a bitcoin into ethereum. This means that you can use bitcoin native limited scripting capability to lock a bitcoin into a contract that is directly connected to an ethereum contract, which can then issue an ethereum based token that is guaranteed to be backed by bitcoin. The relay is under development and as implementations are tested and proved to be secure, we will list them here.
+* **Use a Bitcoin relay to convert a 2 way peg**: [the bitcoin relay](https://github.com/ethereum/btcrelay/) is a piece of code that allows you to sidechain a bitcoin into ethereum. This means that you can use Bitcoin's native limited scripting capability to lock a bitcoin into a contract that is directly connected to an ethereum contract, which can then issue an ethereum based token that is guaranteed to be backed by bitcoin. The relay is under development and as implementations are tested and proved to be secure, we will list them here.
 
 
 ### 3. Importing from the presale wallet
 
-Before you decide to import your presale ether wallet, please remember that Frontier is a public, live test network. **It is dangerous, potentially full of bugs and is prone to instability. If you understand the risks and still want to go forward, then importing your presale wallet is very easy.
+Before you decide to import your presale ether wallet, please remember that Frontier is a public, live test network. **It is dangerous, potentially full of bugs and is prone to instability.** If you understand the risks and still want to go forward, then importing your presale wallet is very easy.
 
 If you are still on the console, then quit it by pressing _control+C_ multiple times and pressing enter.
 
@@ -116,13 +116,13 @@ This will prompt for your password and imports your ether presale account. It ca
 
 If this does not work, please do not hesitate in contacting us on our [forums](http://forum.ethereum.org), [reddit](http://reddit.com/r/ethereum) or at **info (at) ethereum.org**.
 
-If you don't feel comfortable securing your ether right now but just want to check that your presale wallet is included in the blockchain, then use our [online balance checker](#balance)
+If you don't feel comfortable securing your ether right now but just want to check that your presale wallet is included in the blockchain, then use our [online balance checker](#balance).
 
 Read [more about accounts](http://guide.ethereum.org/managing_accounts.html).
 
 ### 4. Get ether from a friend
 
-That is by far the easiest way to get ether, but you need to know someone who is willing to give you a hand. If you do have such a friend, then you can send them one of your addresses the the hopes of getting some sweet sweet ether:
+That is by far the easiest way to get ether, but you need to know someone who is willing to give you a hand. If you do have such a friend, then you can send them one of your addresses in the hopes of getting some sweet sweet ether:
 
     eth.accounts[0] 
 
@@ -132,7 +132,7 @@ Ether sent to your account should show up almost immediately, transactions being
 
 ## Sending your first transaction
 
-**ATTENTION: Ethereum addresses don't have, yet, built-in checks on them. That means that if you mistype an address, your ether will be lost forever, without a secondary confirmation window. If you are moving a significant amount, start with smaller quantities that you can afford to lose, until you feel comfortable enough.**
+**ATTENTION: Ethereum addresses don't have built-in checks on them yet. That means that if you mistype an address, your ether will be lost forever, without a secondary confirmation window. If you are moving a significant amount, start with smaller quantities that you can afford to lose, until you feel comfortable enough.**
 
 There are two types of accounts in Ethereum: *normal accounts*, holding ether that can only be moved with a private key and *contracts*, which hold ether only controlled by their own internal code. In this section we focus on the former. The remainder of this guide will be dedicated to the latter.
 

--- a/views/content/foundation.md
+++ b/views/content/foundation.md
@@ -51,9 +51,9 @@ It is the aim that decentralized and open technologies will be developed, nurtur
 
 ![Portrait of David Kay](/images/portraits/david-ben-kay.jpg)
 
-**David Ben Kay is an lawyer specialized in creating innovative intellectual property solutions for emerging markets.** David is a US lawyer who has worked and lived in China for the past 30 years. He was the managing partner of the Beijing office of Denton Hall (later Dentons) and the General Counsel of Microsoft China. Over the past 8 years David has run his own consulting company and business incubator in Beijing's 798 Art District.
+**David Ben Kay is a lawyer specialized in creating innovative intellectual property solutions for emerging markets.** David is a US lawyer who has worked and lived in China for the past 30 years. He was the managing partner of the Beijing office of Denton Hall (later Dentons) and the General Counsel of Microsoft China. Over the past 8 years David has run his own consulting company and business incubator in Beijing's 798 Art District.
 
-[Linkedin](https://www.linkedin.com/in/davidbenkayhttps://twitter.com/davidbenkay)
+[Linkedin](https://www.linkedin.com/in/davidbenkay), [Twitter](https://twitter.com/davidbenkay)
 
 ----
 
@@ -65,7 +65,7 @@ It is the aim that decentralized and open technologies will be developed, nurtur
 
 ![Portrait of Bernd Lapp](/images/portraits/bernd-lapp.jpg)
 
-Bernd Lapp has several years of management experience across multiple industries, including finance, digital media and sports. In his last role as Head of Sales he was responsible for defining and implementing the sales strategy for the most successful mobile banking app in Germany. Bernd is an advising the Executive Director of the Ethereum Foundation on topics such as PR, Marketing, Communications, Funding and Membership Programs and related HR and business planning..
+Bernd Lapp has several years of management experience across multiple industries, including finance, digital media and sports. In his last role as Head of Sales he was responsible for defining and implementing the sales strategy for the most successful mobile banking app in Germany. Bernd is advising the Executive Director of the Ethereum Foundation on topics such as PR, Marketing, Communications, Funding and Membership Programs and related HR and business planning.
 
 
 [LinkedIn](https://ch.linkedin.com/in/berndlapp)
@@ -77,7 +77,7 @@ Bernd Lapp has several years of management experience across multiple industries
 
 ![Portrait of Stefano Bertolo](/images/portraits/stefano-bartolo.jpg)
 
-Stefano Bertolo is a civil servant advising Ethereum in a strictly personal capacity and with the formal permission of his employer. An alumnus of Rutgers University, where he earned his Ph.D. in philosophy and cognitive psychology, he has done post-doctoral work on human language learning at the Massachusetts Institute of Technology and worked as an artificial intelligence programmer at Cycorp. An enthusiast of prediction markets, he has earned the rank of Superforecaster in the Good Judgement Project. Stefano lives in Luxembourg where for the past ten years he has worked on public research and development funding for international projects in data management and analytics.
+Stefano Bertolo is a civil servant advising Ethereum in a strictly personal capacity and with the formal permission of his employer. An alumnus of Rutgers University, where he earned his Ph.D. in philosophy and cognitive psychology, he has done post-doctoral work on human language learning at the Massachusetts Institute of Technology and worked as an artificial intelligence programmer at Cycorp. An enthusiast of prediction markets, he has earned the rank of Superforecaster in the Good Judgment Project. Stefano lives in Luxembourg where for the past ten years he has worked on public research and development funding for international projects in data management and analytics.
 
 [LinkedIn](https://www.linkedin.com/in/stefanobertolo), [Twitter](https://twitter.com/sclopit)
 

--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -122,7 +122,7 @@ Now you have the compiler installed, you need now reformat your contract by remo
 
     var greeterCompiled = web3.eth.compile.solidity(greeterSource)
 
-You have now compiled your code. Now you need to get it ready for deployment, this includes setting some variables up, like what greeting you want to use. Edit the first line below to something more interesting than 'Hello World!" and execute these commands:
+You have now compiled your code. Now you need to get it ready for deployment, this includes setting some variables up, like what greeting you want to use. Edit the first line below to something more interesting than "Hello World!" and execute these commands:
 
     var _greeting = "Hello World!"
     var greeterContract = web3.eth.contract(greeterCompiled.greeter.info.abiDefinition);
@@ -181,7 +181,7 @@ In order to other people to run your contract they need two things: the address 
     greeterCompiled.greeter.info.abiDefinition;
     greeter.address;
 
-Then you can instantiate a javascript object which can be used to call the contract on any machine connected to the network. Replace 'ABI' and 'address' to create a contract object in javascript:
+Then you can instantiate a JavaScript object which can be used to call the contract on any machine connected to the network. Replace 'ABI' and 'Address' to create a contract object in JavaScript:
 
     var greeter = eth.contract(ABI).at(Address);
 
@@ -199,7 +199,7 @@ Replace _greeterAddress_ with your contract's address.
 
 You must be very excited to have your first contract live, but this excitement wears off sometimes, when the owners go on to write further contracts, leading to the unpleasant sight of abandoned contracts on the blockchain. In the future, blockchain rent might be implemented in order to increase the scalability of the blockchain but for now, be a good citizen and humanely put down your abandoned bots. 
 
-A transaction will need to be sent to the network and a fee to be paid for the changes made to the blockchain after the code below is ran. The suicide is subsidized by the network so it will cost much less than a usual transaction.
+A transaction will need to be sent to the network and a fee to be paid for the changes made to the blockchain after the code below is run. The suicide is subsidized by the network so it will cost much less than a usual transaction.
 
     greeter.kill.sendTransaction({from:eth.accounts[0]})
 

--- a/views/content/token.md
+++ b/views/content/token.md
@@ -31,7 +31,7 @@ This is the code for the contract we're building:
         }
     }
 
-If you have ever programmed, you won't find it hard to understand what it does: it is a contract that generates 10 thousand tokens to the creator of the contract, and then allows anyone with enough balance to send it to others. These tokens are the minimum tradeable unit and cannot be subdivided, but for the final users could be presented as a 100 units subdividable by 100 subunits, so owning a single token would represent having 0.01% of the total. If your application needs more fine grained atomic divisibility, then just increase the initial issuance amount.
+If you have ever programmed, you won't find it hard to understand what it does: it is a contract that generates 10 thousand tokens to the creator of the contract, and then allows anyone with enough balance to send it to others. These tokens are the minimum tradeable unit and cannot be subdivided, but for the final users could be presented as 100 units subdividable by 100 subunits, so owning a single token would represent having 0.01% of the total. If your application needs more fine grained atomic divisibility, then just increase the initial issuance amount.
 
 In this example we declared the mapping "coinBalanceOf" to be public, this will automatically create a 'get' function that returns any account's balance.
 
@@ -105,7 +105,7 @@ If a friend has registered a name on the registrar you can send it without knowi
     token.sendCoin.sendTransaction(registrar.addr("Alice"), 2000, {from: eth.accounts[0]})
 
 
-Note that our first function **coinBalanceOf** was simply called directly on the contract instance and returned a value. This was possible since this was a simple read operation that incurs no state change and which executes locally and synchronously. Our second function **sendCoin** needs a **.sendTransaction()** call. Since this function is meant to change the state (write operation), it is sent as a transaction to the network to be picked up by miners and included in the canonical blockchain. As a result the consensus state of all participant nodes will adequately reflect the state changes resulting from executing the transaction. Sender address needs to be sent as part of the transaction to fund the fuel needed to run the transaction. Now, wait until the transaction is included in a block and check both accounts balances:
+Note that our first function **coinBalanceOf** was simply called directly on the contract instance and returned a value. This was possible since this was a simple read operation that incurs no state change and which executes locally and synchronously. Our second function **sendCoin** needs a **.sendTransaction()** call. Since this function is meant to change the state (write operation), it is sent as a transaction to the network to be picked up by miners and included in the canonical blockchain. As a result the consensus state of all participant nodes will adequately reflect the state changes resulting from executing the transaction. Sender address needs to be sent as part of the transaction to fund the fuel needed to run the transaction. Now, wait until the transaction is included in a block and check both accounts' balances:
 
     token.coinBalanceOf.call(eth.accounts[0])/100 + "% of all tokens"
     token.coinBalanceOf.call(eth.accounts[1])/100 + "% of all tokens"
@@ -124,14 +124,14 @@ Right now this "cryptocurrency" is quite limited as there will only ever be 10,0
       }
     }
 
-You could modify this to anything else: maybe reward someone who finds a solution for a new puzzle, wins a game of chess, install a solar panel—as long as that can be somehow translated to a contract. Or maybe you want to create a central bank for your personal country, so you can keep track of hours worked, favours owed or control of property. In that case you might want to add a function to allow the bank to remotely freeze funds and destroy tokens if needed. 
+You could modify this to anything else: maybe reward someone who finds a solution for a new puzzle, wins a game of chess, installs a solar panel—as long as that can be somehow translated to a contract. Or maybe you want to create a central bank for your personal country, so you can keep track of hours worked, favours owed or control of property. In that case you might want to add a function to allow the bank to remotely freeze funds and destroy tokens if needed. 
 
 
 ### Register a name for your coin
 
 **The name registrar contract has changed in Frontier and the following section is only valid for the Olympic test net. Please wait while we update it.**
 
-The commands mentioned only work because you have token javascript object instantiated on your local machine. If you send tokens to someone they won't be able to move them forward because they don't have the same object and wont know where to look for your contract or call its functions. In fact if you restart your console these objects will be deleted and the contracts you've been working on will be lost forever. So how do you instantiate the contract on a clean machine? 
+The commands mentioned only work because you have a token JavaScript object instantiated on your local machine. If you send tokens to someone they won't be able to move them forward because they don't have the same object and won't know where to look for your contract or call its functions. In fact if you restart your console these objects will be deleted and the contracts you've been working on will be lost forever. So how do you instantiate the contract on a clean machine? 
 
 There are two ways. Let's start with the quick and dirty, providing your friends with a reference to your contract’s ABI:
 
@@ -141,7 +141,7 @@ Just replace the address at the end for your own token address, then anyone that
 
 All accounts are referenced in the network by their public address. But addresses are long, difficult to write down, hard to memorize and immutable. The last one is specially important if you want to be able to generate fresh accounts in your name, or upgrade the code of your contract. In order to solve this, there is a default name registrar contract which is used to associate the long addresses with short, human-friendly names.
 
-Names have to use only alphanumeric characters and, cannot contain blank spaces. In future releases the name registrar will likely implement a bidding process to prevent name squatting but for now, it works on a first come first served basis: as long as no one else registered the name, you can claim it.
+Names have to use only alphanumeric characters and cannot contain blank spaces. In future releases the name registrar will likely implement a bidding process to prevent name squatting but for now, it works on a first come first served basis: as long as no one else registered the name, you can claim it.
 
 
 First, if you register a name, then you won't need the hardcoded address in the end. Select a nice coin name and try to reserve it for yourself. First, select your name:

--- a/views/includes/footer.jade
+++ b/views/includes/footer.jade
@@ -9,7 +9,7 @@ footer.scrollme
               ul
                 li Source code on 
                     a(href='http://github.com/ethereum/') GitHub
-                li Read the full user guide at 
+                li Read the full user guide 
                     a(href='http://guide.ethereum.org/') as a GitBook
                 li Learn the  
                     a(href='https://solidity.readthedocs.org/') Solidity Language

--- a/views/mixins/recipes.jade
+++ b/views/mixins/recipes.jade
@@ -143,7 +143,7 @@ mixin crowdsaleRecipe(header)
 
   p Do you already have many ideas as to what to develop on Ethereum? Maybe you need help and some funds to bring them to life, but who would lend money to someone they don’t trust?
 
-  p Using Ethereum you can create a contract that will hold contributor's money until any given date or goal is reached. Depending on the outcome, the funds will either be released to the project owners, or safely returned back to the contributors. All without requiring a centralized arbitrator, clearing house or having to trust anyone. 
+  p Using Ethereum you can create a contract that will hold contributors' money until any given date or goal is reached. Depending on the outcome, the funds will either be released to the project owners, or safely returned back to the contributors. All without requiring a centralized arbitrator, clearing house or having to trust anyone.
 
   p You can even use the token you created earlier to keep track of the distribution of rewards.
 
@@ -180,7 +180,7 @@ mixin daoRecipe(header)
     div.number 6 
     | Create a democratic autonomous organization
 
-  p Now that you have developed your idea and secured funds, what’s next? You have to hire managers, find a trustworthy CFO to handle the accounts, run Board meetings and do bunch of paperwork. 
+  p Now that you have developed your idea and secured funds, what’s next? You have to hire managers, find a trustworthy CFO to handle the accounts, run Board meetings and do a bunch of paperwork.
 
   p Or you can simply leave all that to an Ethereum contract. It will collect proposals from your backers, and submit them through a completely transparent voting process.
 

--- a/views/mixins/recipes.jade
+++ b/views/mixins/recipes.jade
@@ -275,9 +275,6 @@ mixin futureRecipe(header)
     li
       a(href='http://www.hitfin.com') HitFin
       | Financial derivatives trading and settlement
-    li 
-      a(href='http://etherparty.io')  Etherparty
-      | Smart contract deployment tools
     li
       a(href='http://chriseth.github.io/browser-solidity/') Solidity Online
       | Solidity Online Compiler


### PR DESCRIPTION
There were many potential editing issues I noticed and chose not to fix. Most of these would require either subjective style choices or more information than I had available.

- Inconsistent use of "-sation" versus "-zation". (3 matches versus 34 matches)

- It's unclear whether "ether" is countable or uncountable.
  * `The funding goal is the amount of ether to be raised`
  * `If the proposal passed then you should be able to see Bob's ethers arriving on his address`

- Inconsistent use of "amongst" and "among". (1 match vs 2 matches)

- Inconsistent capitalization of "Ethereum" in plain text.
  * `Finally, by creating your token in Ethereum, your coin will be compatible with any other contract running on ethereum`

- Mixed and inconsistent use of words and digits in plain text numerals.
  * `If you have ever programmed, you won't find it hard to understand what it does: it is a contract that generates 10 thousand tokens to the creator of the contract, and then allows anyone with enough balance to send it to others`
  * `It should have all the 10 000 tokens that were created once the contract was published`
  * `Right now this "cryptocurrency" is quite limited as there will only ever be 10,000 coins and all are controlled by the coin creator, but you can change that`

- Irregular or nonstandard use of commas.
  * `You could for example reward ethereum miners, by creating a transaction that will reward who found the current block`

- Mixed and inconsistent use of vertical and smart apostrophes. (' versus ’)
  * `Let's start with the quick and dirty, providing your friends with a reference to your contract’s ABI`

- Inconsistent use of vertical and smart quotes. (" versus ” and “)
  * `We’ll call him the “Greeter”`
  * `To start you will create a classic "Hello World" contract, then you can build you own crypto token to send to whomever you like`

- Inconsistent use of markdown, quotes, and apostrophes to indicate variable names in plain text.
  * `Replace 'ABI' and 'address' to create a contract object in javascript`
  * `Replace _greeterAddress_ with your contract's address`

- On the [CLI page](https://www.ethereum.org/cli), this section could use some clarification. Do both Geth and Eth run a full Ethereum node implemented in Go, or is that something only Geth does, while Eth runs an Ethereum node implemented in C++?
  * `Geth and Eth are multipurpose command line tools that runs a full Ethereum node implemented in Go.`

- I didn't proofread the legal terms. There is at least one capitalization error there.
  * `therefore, some of the above limitations in this section may not apply to a user.`

- Missing and inconsistent use of hyphens in compound modifiers.
  * `Could your business be enhanced by operating on a cryptographically secure, decentralized, tamper proof network?`
  * `Smart contracts are account holding objects on the ethereum blockchain`
  * `If you have the SolC Solidity Compiler installed, you need now reformat by removing line breaks so it fits into a string variable`
  * `Now you have the compiler installed, you need now reformat your contract by removing line-breaks so it fits into a string variable`

- Copious amounts of trailing spaces, such as in [`views/mixins/recipes.jade`](https://github.com/ethereum/ethereum-org/blob/master/views/mixins/recipes.jade#L255)

- Pervasive lack of Oxford commas.