### PR TITLE
When installing geth, do not say you're installing cpp-ethereum

### DIFF
--- a/views/content/cli.md
+++ b/views/content/cli.md
@@ -29,7 +29,7 @@ Install [Homebrew](http://brew.sh/) and make sure it's up to date:
     brew update
     brew upgrade
 
-Then use these commands to install cpp-ethereum:
+Then use these commands to install ethereum:
 
     brew tap ethereum/ethereum
     brew install ethereum


### PR DESCRIPTION
I think there is a copy & paste error in the section describing how to install geth on OSX:

It says `Then use these commands to install cpp-ethereum` when you really mean `Then use these commands to install ethereum`