### PR TITLE
Remove duplicate type declaration

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -284,7 +284,7 @@ This is acceptable for a price that doesn't change very often, as every new pric
 The next step is making the buy and sell functions:
 
     function buy() returns (uint amount){
-        amount = msg.value / buyPrice;                // calculates the amount
+        amount = msg.value / buyPrice;                     // calculates the amount
         if (balanceOf[this] < amount) throw;               // checks if it has enough to sell
         balanceOf[msg.sender] += amount;                   // adds the amount to buyer's balance
         balanceOf[this] -= amount;                         // subtracts amount from seller's balance

--- a/views/content/token.md
+++ b/views/content/token.md
@@ -284,7 +284,7 @@ This is acceptable for a price that doesn't change very often, as every new pric
 The next step is making the buy and sell functions:
 
     function buy() returns (uint amount){
-        uint amount = msg.value / buyPrice;                // calculates the amount
+        amount = msg.value / buyPrice;                // calculates the amount
         if (balanceOf[this] < amount) throw;               // checks if it has enough to sell
         balanceOf[msg.sender] += amount;                   // adds the amount to buyer's balance
         balanceOf[this] -= amount;                         // subtracts amount from seller's balance


### PR DESCRIPTION
When I copy & paste the snippet, I was getting `Identifier already declared error`.

I also noticed that [the full code](https://www.ethereum.org/token#the-code) does not raise error because both `buy()`  and `sell()` functions do not have return values which are different from the code snippets.