### PR TITLE
Typos + removed white spaces

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -1,4 +1,3 @@
-
 ### The Coin
 
 We are going to create a digital token. Tokens in the ethereum ecosystem can represent any fungible tradable good: coins, loyalty points, gold certificates, IOUs, in game items, etc. Since all tokens implement some basic features in a standard way, this also means that your token will be instantly compatible with the ethereum wallet and any other client or contract that uses the same standards.
@@ -582,13 +581,3 @@ Unicorn tokens are memorabilia created exclusively for those who have donated to
 ### Now what?
 
 You just learned how you can use ethereum to issue a token, that can represent anything you want. But what can you do with the tokens? You can use, for instance, the tokens to [represent a share in a company](./dao#the-stakeholder-association) or you can use a [central committee](./dao#the-code) to vote on when to issue new coins to control inflation. You can also use them to raise money for a cause, via a [crowdsale](./crowdsale). What will you build next?
-
-
-
-
-
-
-
-
-
-

--- a/views/content/token.md
+++ b/views/content/token.md
@@ -1,7 +1,7 @@
 
-### The Coin 
+### The Coin
 
-We are going to create a digital token. Tokens in the ethereum ecosystem can represent any fungible tradable good: coins, loyalty points, gold certificates, IOUs, in game items, etc. Since all tokens implement some basic features in a standard way, this also means that your token will be instantly compatible with the ethereum wallet and any other client or contract that uses the same standards. 
+We are going to create a digital token. Tokens in the ethereum ecosystem can represent any fungible tradable good: coins, loyalty points, gold certificates, IOUs, in game items, etc. Since all tokens implement some basic features in a standard way, this also means that your token will be instantly compatible with the ethereum wallet and any other client or contract that uses the same standards.
 
 #### The code
 
@@ -9,7 +9,7 @@ If you are in a hurry, here's the final code of the basic token:
 
     contract tokenRecipient { function receiveApproval(address _from, uint256 _value, address _token, bytes _extraData); }
 
-    contract MyToken { 
+    contract MyToken {
         /* Public variables of the token */
         string public name;
         string public symbol;
@@ -27,55 +27,55 @@ If you are in a hurry, here's the final code of the basic token:
 
         /* Initializes contract with initial supply tokens to the creator of the contract */
         function MyToken(
-            uint256 initialSupply, 
-            string tokenName, 
-            uint8 decimalUnits, 
-            string tokenSymbol, 
+            uint256 initialSupply,
+            string tokenName,
+            uint8 decimalUnits,
+            string tokenSymbol,
             string versionOfTheCode
             ) {
-            balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens                    
+            balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens
             totalSupply = initialSupply;                        // Update total supply
-            name = tokenName;                                   // Set the name for display purposes     
-            symbol = tokenSymbol;                               // Set the symbol for display purposes    
-            decimals = decimalUnits;                            // Amount of decimals for display purposes        
+            name = tokenName;                                   // Set the name for display purposes
+            symbol = tokenSymbol;                               // Set the symbol for display purposes
+            decimals = decimalUnits;                            // Amount of decimals for display purposes
             version = versionOfTheCode;
         }
 
         /* Send coins */
         function transfer(address _to, uint256 _value) {
-            if (balanceOf[msg.sender] < _value) throw;           // Check if the sender has enough   
+            if (balanceOf[msg.sender] < _value) throw;           // Check if the sender has enough
             if (balanceOf[_to] + _value < balanceOf[_to]) throw; // Check for overflows
             balanceOf[msg.sender] -= _value;                     // Subtract from the sender
-            balanceOf[_to] += _value;                            // Add the same to the recipient            
+            balanceOf[_to] += _value;                            // Add the same to the recipient
             Transfer(msg.sender, _to, _value);                   // Notify anyone listening that this transfer took place
         }
 
         /* Allow another contract to spend some tokens in your behalf */
-        function approveAndCall(address _spender, uint256 _value, bytes _extraData) 
+        function approveAndCall(address _spender, uint256 _value, bytes _extraData)
             returns (bool success) {
-            allowance[msg.sender][_spender] = _value;     
+            allowance[msg.sender][_spender] = _value;
             tokenRecipient spender = tokenRecipient(_spender);
-            spender.receiveApproval(msg.sender, _value, this, _extraData); 
-            return true; 
+            spender.receiveApproval(msg.sender, _value, this, _extraData);
+            return true;
         }
 
         /* A contract attempts to get the coins */
         function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
-            if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough   
+            if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough
             if (balanceOf[_to] + _value < balanceOf[_to]) throw;  // Check for overflows
             if (spentAllowance[_from][msg.sender] + _value > allowance[_from][msg.sender]) throw;   // Check allowance
             balanceOf[_from] -= _value;                          // Subtract from the sender
-            balanceOf[_to] += _value;                            // Add the same to the recipient            
+            balanceOf[_to] += _value;                            // Add the same to the recipient
             spentAllowance[_from][msg.sender] += _value;
-            Transfer(_from, _to, _value); 
+            Transfer(_from, _to, _value);
             return true;
-        } 
+        }
 
         /* This unnamed function is called whenever someone tries to send ether to it */
         function () {
             throw;     // Prevents accidental sending of ether
-        }        
-    }     
+        }
+    }
 
 Let's break it down step by step
 
@@ -87,16 +87,16 @@ Let's break it down step by step
 So let's start with the basics. Open the **Wallet** app, go to the *Contracts* tab and then *Deploy New Contract*. On the *Solidity Contract Source code* text field, type the code below:
 
 
-    contract MyToken {         
+    contract MyToken {
         /* This creates an array with all balances */
-        mapping (address => uint256) public balanceOf;   
+        mapping (address => uint256) public balanceOf;
     }
 
 A mapping means an associative array, where you associate addresses with balances. The addresses are in the basic hexadecimal ethereum format, while the balances are integers, ranging from 0 to 115 quattuorvigintillion. If you don't know how much a quattuorvigintillion is, it's many vigintillions more than anything you are planning to use your tokens for. The *public* keyword, means that that variable will be accessible by anyone on the blockchain, meaning all balances are public (as they need to be, in order for clients to display them).
 
 ![Edit New Contract](/images/tutorial/edit-contract.png)
 
-If you published your contract right away, it would work but wouldn't be very useful: it would be a contract that could query the balance of your coin for any address–but since you never created a single coin, every one of them would return 0. So we are going to create a few tokens on startup. Add this code *before* the last closing bracket, just under the *mapping..* line. 
+If you published your contract right away, it would work but wouldn't be very useful: it would be a contract that could query the balance of your coin for any address–but since you never created a single coin, every one of them would return 0. So we are going to create a few tokens on startup. Add this code *before* the last closing bracket, just under the *mapping..* line.
 
 
     function MyToken() {
@@ -104,7 +104,7 @@ If you published your contract right away, it would work but wouldn't be very us
     }
 
 
-Notice that the *function MyToken* has the same name as the *contract MyToken*. This is very important and if you rename one, you have to rename the other too: this is a special, startup function that runs only once and once only when the contract is first uploaded to the network. This function will set the balance of *msg.sender*, the user which deployed the contract, with a balance of 21 million. 
+Notice that the *function MyToken* has the same name as the *contract MyToken*. This is very important and if you rename one, you have to rename the other too: this is a special, startup function that runs only once and once only when the contract is first uploaded to the network. This function will set the balance of *msg.sender*, the user which deployed the contract, with a balance of 21 million.
 
 The choice of 21 million was rather arbitrary, and you can change it to anything you want in the code, but there's a better way: instead, supply it as a parameter for the function, like this:
 
@@ -113,7 +113,7 @@ The choice of 21 million was rather arbitrary, and you can change it to anything
         balanceOf[msg.sender] = initialSupply;
     }
 
-Take a look at the right column besides the contract and you'll see a drop down, written *pick a contract*. Select the "myToken" contract and you'll see that now it shows a section called *Constructor parameters*. These are changeable parameters for your token, so you can reuse the same code and only change these variables in the future.
+Take a look at the right column besides the contract and you'll see a drop down, written *pick a contract*. Select the "MyToken" contract and you'll see that now it shows a section called *Constructor parameters*. These are changeable parameters for your token, so you can reuse the same code and only change these variables in the future.
 
 ![Edit New Contract](/images/tutorial/function-picker.png)
 
@@ -124,7 +124,7 @@ Right now you have a functional contract that created balances of tokens but sin
     function transfer(address _to, uint256 _value) {
         /* Add and subtract new balances */
         balanceOf[msg.sender] -= _value;
-        balanceOf[_to] += _value;        
+        balanceOf[_to] += _value;
     }
 
 This is a very straightforward function: it has a recipient and a value as the parameter and whenever someone calls it, it will subtract the *_value* from their balance and add it to the *_to* balance. Right away there's an obvious problem: what happens if the person wants to send more than it owns? Since we don't want to handle debt in this particular contract, we are simply going to make a quick check and if the sender doesn't have enough funds the contract execution will simply stop. It's also to check for overflows, to avoid having a number so big that it becomes zero again.
@@ -138,7 +138,7 @@ To stop a contract execution mid execution you can either **return** or **throw*
 
         /* Add and subtract new balances */
         balanceOf[msg.sender] -= _value;
-        balanceOf[_to] += _value;        
+        balanceOf[_to] += _value;
     }
 
 
@@ -151,12 +151,12 @@ Now all that is missing is having some basic information about the contract. In 
 And now we update the **constructor function** to allow all those variables to be set up at the start:
 
     /* Initializes contract with initial supply tokens to the creator of the contract */
-    function myToken(uint256 initialSupply, string tokenName, uint8 decimalUnits, string tokenSymbol) {
-        balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens                    
-        name = tokenName;                                   // Set the name for display purposes     
-        symbol = tokenSymbol;                               // Set the symbol for display purposes    
-        decimals = decimalUnits;                            // Amount of decimals for display purposes        
-    }    
+    function MyToken(uint256 initialSupply, string tokenName, uint8 decimalUnits, string tokenSymbol) {
+        balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens
+        name = tokenName;                                   // Set the name for display purposes
+        symbol = tokenSymbol;                               // Set the symbol for display purposes
+        decimals = decimalUnits;                            // Amount of decimals for display purposes
+    }
 
 
 Finally we now need something called **Events**. These are special, empty functions that you call to help clients like the Ethereum Wallet keep track of activities happening in the contract. Events should start with a capital letter. Add this line at the beginning of the contract to declare the event:
@@ -174,7 +174,7 @@ And now your token is ready!
 
 If you aren't there already, open the Ethereum Wallet, go to the contracts tab and then click "deploy new contract".
 
-Now get the token source from above and paste it into the "Solidity source field". If the code compiles without any error, you should see a "pick a contract" drop down on the left. Get it and select the "MyToken" contract. On the right column you'll see all the parameters you need to personalize your own token. You can tweak them as you please, but for the purpose of this tutorial we recommend you to pick these parameters: 10,000 as the supply, any name you want, "%" for a symbol and 2 decimal places. Your app should be looking like this:
+Now get the token source from above and paste it into the "Solidity source field". If the code compiles without any error, you should see a "pick a contract" drop down on the right. Get it and select the "MyToken" contract. On the right column you'll see all the parameters you need to personalize your own token. You can tweak them as you please, but for the purpose of this tutorial we recommend you to pick these parameters: 10,000 as the supply, any name you want, "%" for a symbol and 2 decimal places. Your app should be looking like this:
 
 [![Ethereum Wallet Screenshot 2015-12-03 at 3.50.36 PM 10](/images/tutorial/Ethereum-Wallet-Screenshot-2015-12-03-at-3.50.36-PM-10.png)](/images/tutorial/Ethereum-Wallet-Screenshot-2015-12-03-at-3.50.36-PM-10.png)
 
@@ -199,26 +199,26 @@ And now you have your own crypto token! Tokens by themselves can be useful as [v
 
 You can deploy your whole crypto token without ever touching a line of code, but the real magic happens when you start customizing it. The following sections will be suggestions on functions you can add to your token to make it fit your needs more.
 
-#### Centralized Administrator 
+#### Centralized Administrator
 
 All dapps are fully decentralized by default, but that doesn't mean they can't have some sort of central manager, if you want them to. Maybe you want the ability to mint more coins, maybe you want to ban some people from using your currency. You can add any of those features, but the catch is that you can only add them at the beginning, so all the token holders will always know exactly the rules of the game before they decide to own one.
 
 For that to happen, you need a central controller of currency. This could be a simple account, but could also be a contract and therefore the decision on creating more tokens will depend on the contract: if it's a democratic organization that can be up to vote, or maybe it can be just a way to limit the power of the token owner.
 
-In order to do that we'll learn a very useful property of contracts: **inheritance**. Inheritance allows a contract to acquire properties of a parent contract, without having to redefine all of them. This makes the code cleaner and easier to reuse. Add this code to the first line of your code, **before contract myToken {**.
+In order to do that we'll learn a very useful property of contracts: **inheritance**. Inheritance allows a contract to acquire properties of a parent contract, without having to redefine all of them. This makes the code cleaner and easier to reuse. Add this code to the first line of your code, **before contract MyToken {**.
 
     contract owned {
         address public owner;
-        
+
         function owned() {
             owner = msg.sender;
         }
-        
+
         modifier onlyOwner {
             if (msg.sender != owner) throw;
             _
         }
-        
+
         function transferOwnership(address newOwner) onlyOwner {
             owner = newOwner;
         }
@@ -227,17 +227,17 @@ In order to do that we'll learn a very useful property of contracts: **inheritan
 
 This creates a very basic contract that doesn't do anything except define some generic functions about a contract that can be "owned". Now the next step is just add the text *is owned* to your token:
 
-    function myToken is owned {
+    function MyToken is owned {
         /* the rest of the contract as usual */
 
 
-This means that all the functions inside **myToken** now can access the variable *owner* and the modifier *onlyOwner*. The contract also gets a function to transfer ownership. Since it might be interesting to set the owner of the contract at startup, you can also add this to the *constructor function*: 
+This means that all the functions inside **MyToken** now can access the variable *owner* and the modifier *onlyOwner*. The contract also gets a function to transfer ownership. Since it might be interesting to set the owner of the contract at startup, you can also add this to the *constructor function*:
 
     function MyToken(
-        uint256 initialSupply, 
-        string tokenName, 
-        uint8 decimalUnits, 
-        string tokenSymbol, 
+        uint256 initialSupply,
+        string tokenName,
+        uint8 decimalUnits,
+        string tokenSymbol,
         address centralMinter
         ) {
         if(centralMinter != 0 ) owner = msg.sender;
@@ -250,7 +250,7 @@ Suppose you want the amount of coins in circulation to change. This is the case 
 Now let's add a new function finally that will enable the owner to create new tokens:
 
     function mintToken(address target, uint256 mintedAmount) onlyOwner {
-        balanceOf[target] += mintedAmount;  
+        balanceOf[target] += mintedAmount;
         totalSupply += mintedAmount;
         Transfer(0, owner, mintedAmount);
         Transfer(owner, target, mintedAmount);
@@ -264,7 +264,7 @@ Depending on your use case, you might need to have some regulatory hurdles on wh
 
 Add this variable and function anywhere inside the contract. You can put them anywhere but for good practice we recommend you put the mappings with the other mappings and events with the other events.
 
-    mapping (address => bool) public frozenAccount; 
+    mapping (address => bool) public frozenAccount;
     event FrozenFunds(address target, bool frozen);
 
     function freezeAccount(address target, bool freeze) onlyOwner {
@@ -281,10 +281,10 @@ Now any account that is frozen will still have their funds intact, but won't be 
 
         if (!approvedAccount[msg.sender]) throw;
 
-         
+
 #### Automatic selling and buying
 
-So far, you've relied on utility and trust to value your token. But if you want you can make the token's value be backed by ether (or other tokens) by creating a fund that automatically sells and buys them at market value. 
+So far, you've relied on utility and trust to value your token. But if you want you can make the token's value be backed by ether (or other tokens) by creating a fund that automatically sells and buys them at market value.
 
 First, let's set the price for buying and selling:
 
@@ -296,7 +296,7 @@ First, let's set the price for buying and selling:
         buyPrice = newBuyPrice;
     }
 
-This is acceptable for a price that doesn't change very often, as every new price change will require you to execute a transaction and spend a bit of ether. If you want to have a constant floating price we recommend investigating [standard data feeds](https://github.com/ethereum/wiki/wiki/Standardized_Contract_APIs#data-feeds)    
+This is acceptable for a price that doesn't change very often, as every new price change will require you to execute a transaction and spend a bit of ether. If you want to have a constant floating price we recommend investigating [standard data feeds](https://github.com/ethereum/wiki/wiki/Standardized_Contract_APIs#data-feeds)
 
 The next step is making the buy and sell functions:
 
@@ -334,9 +334,9 @@ Everytime you make a transaction on ethereum you need to pay a fee to the miner 
 
 In order to do that, first you need to create a variable that will hold the threshold amount and a function to change it. If you don't know any value, set it to **5 finney (0.005 ether)**.
 
-    
+
     uint minBalanceForAccounts;
-    
+
     function setMinBalance(uint minimumBalanceInFinney) onlyOwner {
          minBalanceForAccounts = minimumBalanceInFinney * 1 finney;
     }
@@ -359,11 +359,11 @@ You can also instead change it so that the fee is paid forward to the receiver b
             _to.send(sell((minBalanceForAccounts-_to.balance)/sellPrice));
     }
 
-This will ensure that no account receiving the token has less than the necessary ether to pay the fees. 
+This will ensure that no account receiving the token has less than the necessary ether to pay the fees.
 
 #### Proof of Work
 
-There are some ways to tie your coin supply to a mathematical formula. One of the simplest ways would be to make it a "merged mining" with ether, meaning that anyone who finds a block on ethereum would also get a reward from your coin, given that anyone calls the reward function on that block. You can do it using the [special keyword coinbase](https://solidity.readthedocs.org/en/latest/units-and-global-variables.html#block-and-transaction-properties) that refers to the miner who finds the block. 
+There are some ways to tie your coin supply to a mathematical formula. One of the simplest ways would be to make it a "merged mining" with ether, meaning that anyone who finds a block on ethereum would also get a reward from your coin, given that anyone calls the reward function on that block. You can do it using the [special keyword coinbase](https://solidity.readthedocs.org/en/latest/units-and-global-variables.html#block-and-transaction-properties) that refers to the miner who finds the block.
 
     function giveBlockReward() {
         balanceOf[block.coinbase] += 1;
@@ -381,14 +381,14 @@ It's also possible to add a mathematical formula, so that anyone who can do math
 
 Of course while calculating cubic roots can be hard for someone to do on their heads, they are very easy with a calculator, so this game could be easily broken by a computer. Also since the last winner can choose the next challenge, they could pick something they know and therefore would not be a very fair game to other players. There are tasks that are easy for humans but hard for computers but they are usually very hard to code in simple scripts like these. Instead a fairer system should be one that is very hard for a computer to do, but isn't very hard for a computer to verify. A great candidate would be to create a hash challenge where the challenger has to generate hashes from multiple numbers until they find one that is lower than a given difficulty.
 
-This process was first proposed by Adam Back in 1997 as [Hashcash](https://en.wikipedia.org/wiki/Hashcash) and then was implemented in Bitcoin by Satoshi Nakamoto as **Proof of work** in 2008. Ethereum was launched using such system for it's security model, but is planning to move from a Proof of Work security model into a [mixed proof of stake and betting system called *Casper*](https://blog.ethereum.org/2015/12/28/understanding-serenity-part-2-casper/). 
+This process was first proposed by Adam Back in 1997 as [Hashcash](https://en.wikipedia.org/wiki/Hashcash) and then was implemented in Bitcoin by Satoshi Nakamoto as **Proof of work** in 2008. Ethereum was launched using such system for it's security model, but is planning to move from a Proof of Work security model into a [mixed proof of stake and betting system called *Casper*](https://blog.ethereum.org/2015/12/28/understanding-serenity-part-2-casper/).
 
 But if you like Hashing as a form of random issuance of coins, you can still create your own ethereum based currency that has a proof of work issuance:
 
     bytes32 public currentChallenge;                         // The coin starts with a challenge
     uint public timeOfLastProof;                             // Variable to keep track of when rewards were given
     uint public difficulty = 10**32;                         // Difficulty starts reasonably low
-    
+
     function proofOfWork(uint nonce){
         bytes8 n = bytes8(sha3(nonce, currentChallenge));    // Generate a random hash based on input
         if (n < bytes8(difficulty)) throw;                   // Check if it's under the difficulty
@@ -396,7 +396,7 @@ But if you like Hashing as a form of random issuance of coins, you can still cre
         uint timeSinceLastProof = (now - timeOfLastProof);  // Calculate time since last reward was given
         if (timeSinceLastProof <  5 seconds) throw;         // Rewards cannot be given too quickly
         balanceOf[msg.sender] += timeSinceLastProof / 60 seconds;  // The reward to the winner grows by the minute
-        
+
         difficulty = difficulty * 10 minutes / timeSinceLastProof + 1;  // Adjusts the difficulty
 
         timeOfLastProof = now;                              // Reset the counter
@@ -409,7 +409,7 @@ Also change the **Constructor function** (the one that has the same name as the 
 
 Once the contract is online, select the function "Proof of work", add your favorite number on the **nonce** field and try to execute it. If the confirmation window gives a red warning saying *"Data can't be execute"* go back and pick another number until you find one that allows the transaction to go forward: this process is random. If you find one you will be awarded 1 token for every minute that has passed since the last reward was given, and then the challenge difficulty will be adjusted up or down to target an average of 10 minutes per reward.
 
-This process of trying to find the number that will give you a reward is what is called *mining*: if difficulty rises it can be very hard to find a lucky number, but it will be always easy to verify that you found one. 
+This process of trying to find the number that will give you a reward is what is called *mining*: if difficulty rises it can be very hard to find a lucky number, but it will be always easy to verify that you found one.
 
 
 ### Improved Coin
@@ -437,13 +437,13 @@ If you add all the advanced options, this is how the final code should look like
         }
     }
 
-    
-    contract tokenRecipient { 
-        function receiveApproval(address _from, uint256 _value, address _token); 
+
+    contract tokenRecipient {
+        function receiveApproval(address _from, uint256 _value, address _token);
     }
 
 
-    contract MyToken is owned { 
+    contract MyToken is owned {
         /* Public variables of the token */
         string public name;
         string public symbol;
@@ -455,7 +455,7 @@ If you add all the advanced options, this is how the final code should look like
 
         /* This creates an array with all balances */
         mapping (address => uint256) public balanceOf;
-        mapping (address => bool) public frozenAccount; 
+        mapping (address => bool) public frozenAccount;
         mapping (address => mapping (address => uint256)) public allowance;
         mapping (address => mapping (address => uint256)) public spentAllowance;
 
@@ -465,58 +465,58 @@ If you add all the advanced options, this is how the final code should look like
 
         /* Initializes contract with initial supply tokens to the creator of the contract */
         function MyToken(
-            uint256 initialSupply, 
-            string tokenName, 
-            uint8 decimalUnits, 
-            string tokenSymbol, 
-            address centralMinter 
-        ) { 
+            uint256 initialSupply,
+            string tokenName,
+            uint8 decimalUnits,
+            string tokenSymbol,
+            address centralMinter
+        ) {
             if(centralMinter != 0 ) owner = msg.sender;         // Sets the minter
-            balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens                    
-            name = tokenName;                                   // Set the name for display purposes     
-            symbol = tokenSymbol;                               // Set the symbol for display purposes    
+            balanceOf[msg.sender] = initialSupply;              // Give the creator all initial tokens
+            name = tokenName;                                   // Set the name for display purposes
+            symbol = tokenSymbol;                               // Set the symbol for display purposes
             decimals = decimalUnits;                            // Amount of decimals for display purposes
-            totalSupply = initialSupply; 
+            totalSupply = initialSupply;
         }
 
         /* Send coins */
         function transfer(address _to, uint256 _value) {
-            if (balanceOf[msg.sender] < _value) throw;           // Check if the sender has enough   
+            if (balanceOf[msg.sender] < _value) throw;           // Check if the sender has enough
             if (balanceOf[_to] + _value < balanceOf[_to]) throw; // Check for overflows
             if (frozenAccount[msg.sender]) throw;                // Check if frozen
             balanceOf[msg.sender] -= _value;                     // Subtract from the sender
-            balanceOf[_to] += _value;                            // Add the same to the recipient            
+            balanceOf[_to] += _value;                            // Add the same to the recipient
             Transfer(msg.sender, _to, _value);                   // Notify anyone listening that this transfer took place
         }
 
         /* Allow another contract to spend some tokens in your behalf */
         function approveAndCall(address _spender, uint256 _value) returns (bool success) {
-            allowance[msg.sender][_spender] = _value;  
+            allowance[msg.sender][_spender] = _value;
             tokenRecipient spender = tokenRecipient(_spender);
-            spender.receiveApproval(msg.sender, _value, this); 
-            return true;         
+            spender.receiveApproval(msg.sender, _value, this);
+            return true;
         }
 
         /* A contract attempts to get the coins */
         function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
-            if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough   
+            if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough
             if (balanceOf[_to] + _value < balanceOf[_to]) throw;  // Check for overflows
             if (spentAllowance[_from][msg.sender] + _value > allowance[_from][msg.sender]) throw;   // Check allowance
             balanceOf[_from] -= _value;                          // Subtract from the sender
-            balanceOf[_to] += _value;                            // Add the same to the recipient            
+            balanceOf[_to] += _value;                            // Add the same to the recipient
             spentAllowance[_from][msg.sender] += _value;
-            Transfer(_from, _to, _value); 
+            Transfer(_from, _to, _value);
             return true;
-        } 
+        }
 
         /* This unnamed function is called whenever someone tries to send ether to it */
         function () {
             throw;     // Prevents accidental sending of ether
         }
-        
+
         function mintToken(address target, uint256 mintedAmount) onlyOwner {
-            balanceOf[target] += mintedAmount; 
-            totalSupply += mintedAmount; 
+            balanceOf[target] += mintedAmount;
+            totalSupply += mintedAmount;
             Transfer(0, owner, mintedAmount);
             Transfer(owner, target, mintedAmount);
         }
@@ -525,12 +525,12 @@ If you add all the advanced options, this is how the final code should look like
             frozenAccount[target] = freeze;
             FrozenFunds(target, freeze);
         }
-            
+
         function setPrices(uint256 newSellPrice, uint256 newBuyPrice) onlyOwner {
             sellPrice = newSellPrice;
             buyPrice = newBuyPrice;
         }
-        
+
         function buy() {
             uint amount = msg.value / buyPrice;                // calculates the amount
             if (balanceOf[this] < amount) throw;               // checks if it has enough to sell
@@ -546,17 +546,17 @@ If you add all the advanced options, this is how the final code should look like
             msg.sender.send(amount * sellPrice);               // sends ether to the seller
             Transfer(msg.sender, this, amount);                // executes an event reflecting on the change
         }
-    }   
+    }
 
-#### Deploying 
+#### Deploying
 
-Scroll down and you'll see an estimated cost for deployment. If you want you can change the slider to set a smaller fee, but if the price is too below the average market rate your transaction might take longer to pick up. Click *Deploy* and type your password. After a few seconds you'll be redirected to the dashboard and under **Latest transactions** you'll see a line saying "creating contract". Wait for a few seconds for someone to pick your transaction and then you'll see a slow blue rectangle representing how many other nodes have seen your transaction and confirmed them. The more confirmations you have, the more assurance you have that your code has been deployed. 
+Scroll down and you'll see an estimated cost for deployment. If you want you can change the slider to set a smaller fee, but if the price is too below the average market rate your transaction might take longer to pick up. Click *Deploy* and type your password. After a few seconds you'll be redirected to the dashboard and under **Latest transactions** you'll see a line saying "creating contract". Wait for a few seconds for someone to pick your transaction and then you'll see a slow blue rectangle representing how many other nodes have seen your transaction and confirmed them. The more confirmations you have, the more assurance you have that your code has been deployed.
 
 ![Created Token](/images/tutorial/created-token.png)
 
-Click on the link that says *Admin page* and you'll be taken the simplest central bank dashboard in the world,   where you can do anything you want with your newly created currency. 
+Click on the link that says *Admin page* and you'll be taken the simplest central bank dashboard in the world,   where you can do anything you want with your newly created currency.
 
-On the left side under *Read from contract* you have all the options and functions you can use to read information from the contract, for free. If your token has an owner, it will display it's address here. Copy that address and paste it on **Balance of** and it will show you the balance of any account (the balance is also automatically shown on any account page that has tokens). 
+On the left side under *Read from contract* you have all the options and functions you can use to read information from the contract, for free. If your token has an owner, it will display it's address here. Copy that address and paste it on **Balance of** and it will show you the balance of any account (the balance is also automatically shown on any account page that has tokens).
 
 On the right side, under **Write to Contract** you'll see all the functions you can use to alter or change the blockchain in any way. These will cost gas. If you created a contract that allows you to mint new coins, you should have a function called "Mint Token". Select it.
 
@@ -573,7 +573,7 @@ After a few confirmations, the recipient balance will be updated to reflect the 
 
 Once you've deployed your tokens, they will be added to your list of watched tokens, and the total balance will be shown on your account. In order to send tokens, just go to the **Send** tab and select an account that contains tokens. The tokens the account has will be listed just under *Ether*. Select them and then type the amount of tokens you want to send.
 
-If you want to add someone else's token, just go to the **Contracts** tab and click **Watch token**. For example, to add the **Unicorn (🦄)** token to your watch list, just add the address **0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7** and the remaining information will be loaded automatically. Click *Ok* and your token will be added. 
+If you want to add someone else's token, just go to the **Contracts** tab and click **Watch token**. For example, to add the **Unicorn (🦄)** token to your watch list, just add the address **0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7** and the remaining information will be loaded automatically. Click *Ok* and your token will be added.
 
 ![Invisible Unicorns](/images/tutorial/unicorn-token.png)
 


### PR DESCRIPTION
1. Renamed `myToken` to `MyToken`.
2. Typo about contact details (it's on the right, not left).
3. Removed unneeded white spaces.