### PR TITLE
Adjust number of blocks to reflect formula above

### DIFF
--- a/views/content/crowdsale.md
+++ b/views/content/crowdsale.md
@@ -203,10 +203,10 @@ The crowdsale contract specifies a deadline using a timestamp, but the Alarm clo
 
 You can use the following chart for rough estimates for how many blocks to add to the current block to compute the **targetBlock**.
 
-* 1 hour duration (60 minutes): 15 blocks
-* 1 day duration  (1440 minutes):  200 blocks
-* 1 week duration (10,800 minutes): 1,000 blocks
-* 1 month duration (44,640 minutes): 3,000 blocks
+* 1 hour duration (60 minutes): 212 blocks
+* 1 day duration  (1440 minutes):  5082 blocks
+* 1 week duration (10,800 minutes): 38,117 blocks
+* 1 month duration (44,640 minutes): 157,553 blocks
 
 On the **Send** field, you need to send enough ether to pay the transaction fee, plus some more to pay the scheduler. Any extra money sent will be refunded, so sending at least 0.25 ether will probably keep you on the safe side.
 


### PR DESCRIPTION
The indicated number of blocks is wrong based on the provided formula above. For 60 minutes, if a new block is created every 17 seconds, you will have to wait for 212 blocks (+ buffer)