### PR TITLE
Update Google Analytics tracking ID

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -61,7 +61,7 @@ html
         |    },i[r].l=1*new Date();a=s.createElement(o),
         |    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         |    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        |    ga('create', 'UA-47404697-1', 'auto');
+        |    ga('create', 'UA-52040685-2', 'auto');
         |    ga('send', 'pageview');
 
    


### PR DESCRIPTION
This updates the GA tracking ID to be under the same account as the Blog GA.

The existing tracking ID is associated with an account which is no longer under EF control