### PR TITLE
Adding token burn method

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -6,7 +6,7 @@ We are going to create a digital token. Tokens in the ethereum ecosystem can rep
 
 If you just want to copy paste the code, then use this:
 
-    pragma solidity ^0.4.2;
+    pragma solidity ^0.4.8;
     contract tokenRecipient { function receiveApproval(address _from, uint256 _value, address _token, bytes _extraData); }
 
     contract MyToken {
@@ -24,6 +24,9 @@ If you just want to copy paste the code, then use this:
         /* This generates a public event on the blockchain that will notify clients */
         event Transfer(address indexed from, address indexed to, uint256 value);
 
+        /* This notifies clients about the amount burnt */
+        event Burn(address indexed from, uint256 value);
+
         /* Initializes contract with initial supply tokens to the creator of the contract */
         function MyToken(
             uint256 initialSupply,
@@ -40,6 +43,7 @@ If you just want to copy paste the code, then use this:
 
         /* Send coins */
         function transfer(address _to, uint256 _value) {
+            if (_to == 0x0) throw;                               // Prevent transfer to 0x0 address
             if (balanceOf[msg.sender] < _value) throw;           // Check if the sender has enough
             if (balanceOf[_to] + _value < balanceOf[_to]) throw; // Check for overflows
             balanceOf[msg.sender] -= _value;                     // Subtract from the sender
@@ -66,20 +70,33 @@ If you just want to copy paste the code, then use this:
 
         /* A contract attempts to get the coins */
         function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
+            if (_to == 0x0) throw;                                // Prevent transfer to 0x0 address
             if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough
             if (balanceOf[_to] + _value < balanceOf[_to]) throw;  // Check for overflows
-            if (_value > allowance[_from][msg.sender]) throw;   // Check allowance
-            balanceOf[_from] -= _value;                          // Subtract from the sender
-            balanceOf[_to] += _value;                            // Add the same to the recipient
+            if (_value > allowance[_from][msg.sender]) throw;     // Check allowance
+            balanceOf[_from] -= _value;                           // Subtract from the sender
+            balanceOf[_to] += _value;                             // Add the same to the recipient
             allowance[_from][msg.sender] -= _value;
             Transfer(_from, _to, _value);
             return true;
         }
-
-        /* This unnamed function is called whenever someone tries to send ether to it */
-        function () {
-            throw;     // Prevents accidental sending of ether
+    
+        function burn() payable returns (bool success) {
+            if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough
+            balanceOf[_from] -= _value;                          // Subtract from the sender
+            Burn(_from, _value);
+            return true;
         }
+
+        function burnFrom(address _from) payable returns (bool success) {
+            if (balanceOf[_from] < _value) throw;                 // Check if the sender has enough
+            if (_value > allowance[_from][msg.sender]) throw;   // Check allowance
+            balanceOf[_from] -= _value;                          // Subtract from the sender
+            Burn(_from, _value);
+            return true;
+        }
+
+
     }
 
 


### PR DESCRIPTION
In order to prevent users mistakenly transfering to 0x0 address, here's a recommendation to validation at the contract level.

Burning token value would be accomplished by calling the `burn(address _to, uint256 _value)` method.

