### PR TITLE
Remove bug from example token contract

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -574,12 +574,8 @@ If you add all the advanced options, this is how the final code should look like
             uint256 initialSupply,
             string tokenName,
             uint8 decimalUnits,
-            string tokenSymbol,
-            address centralMinter
-        ) token (initialSupply, tokenName, decimalUnits, tokenSymbol) {
-            if(centralMinter != 0 ) owner = centralMinter;      // Sets the owner as specified (if centralMinter is not specified the owner is msg.sender)
-            balanceOf[owner] = initialSupply;                   // Give the owner all initial tokens
-        }
+            string tokenSymbol
+        ) token (initialSupply, tokenName, decimalUnits, tokenSymbol) {}
 
         /* Send coins */
         function transfer(address _to, uint256 _value) {

--- a/views/content/token.md
+++ b/views/content/token.md
@@ -53,7 +53,7 @@ If you just want to copy paste the code, then use this:
             allowance[msg.sender][_spender] = _value;
             return true;
         }
-        
+
         /* Approve and then comunicate the approved contract in a single tx */
         function approveAndCall(address _spender, uint256 _value, bytes _extraData)
             returns (bool success) {
@@ -563,7 +563,6 @@ If you add all the advanced options, this is how the final code should look like
 
         uint256 public sellPrice;
         uint256 public buyPrice;
-        uint256 public totalSupply;
 
         mapping (address => bool) public frozenAccount;
 


### PR DESCRIPTION
There is a bug where if the constructor for MyAdvancedToken is called, specifying a centralMinter different from msg.sender, then the initial supply of tokens is given out twice, to two different addresses.

MyAdvancedToken first makes a call to the super constructor (token), which sets the balance of msg.sender to initialSupply ('balanceOf[msg.sender] = initialSupply;'). Then the constructor for MyAdvancedToken changes the owner to centralMinter ('if(centralMinter != 0 ) owner = centralMinter;') and then sets the balance of owner=centralMinter to initialSupply ('balanceOf[owner] = initialSupply;').

If "msg.sender" and parameter "centralMinter" are different addresses then the actual total supply of coins is 2 * initialSupply = 2 * totalSupply.
This is undesired behaviour.