### PR TITLE
Removed erroneous line (547)

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -58,7 +58,7 @@ If you just want to copy paste the code, then use this:
             return true;
         }
 
-        /* Approve and then comunicate the approved contract in a single tx */
+        /* Approve and then communicate the approved contract in a single tx */
         function approveAndCall(address _spender, uint256 _value, bytes _extraData)
             returns (bool success) {
             tokenRecipient spender = tokenRecipient(_spender);
@@ -544,11 +544,10 @@ If you add all the advanced options, this is how the final code should look like
         function approve(address _spender, uint256 _value)
             returns (bool success) {
             allowance[msg.sender][_spender] = _value;
-            tokenRecipient spender = tokenRecipient(_spender);
             return true;
         }
 
-        /* Approve and then comunicate the approved contract in a single tx */
+        /* Approve and then communicate the approved contract in a single tx */
         function approveAndCall(address _spender, uint256 _value, bytes _extraData)
             returns (bool success) {    
             tokenRecipient spender = tokenRecipient(_spender);


### PR DESCRIPTION
Line 547 on token.md throws an error
ie. line 63 on MyAdvancedToken - I think this line in the contract is erroneous 

`
    /* Allow another contract to spend some tokens in your behalf */
    function approve(address _spender, uint256 _value)
        returns (bool success) {
        allowance[msg.sender][_spender] = _value;
        // tokenRecipient spender = tokenRecipient(_spender); // Error
        return true;
    }
`

Error: 
 Unused local variable
        tokenRecipient spender = tokenRecipient(_spender);
        ^--------------------^

It already exists in the next function

`
    /* Approve and then communicate the approved contract in a single tx */
    function approveAndCall(address _spender, uint256 _value, bytes _extraData)
        returns (bool success) {    
        tokenRecipient spender = tokenRecipient(_spender);
        if (approve(_spender, _value)) {
            spender.receiveApproval(msg.sender, _value, this, _extraData);
            return true;
        }
    }
`

Also fixed some spelling
line 61 "communicate"
line 550 "communicate"