### PR TITLE
keep track of balance for multiple coin purchases

### DIFF
--- a/views/content/crowdsale.md
+++ b/views/content/crowdsale.md
@@ -60,7 +60,7 @@ Now copy this code and let's create the crowdsale:
         function () payable {
             if (crowdsaleClosed) throw;
             uint amount = msg.value;
-            balanceOf[msg.sender] = amount;
+            balanceOf[msg.sender] += amount;
             amountRaised += amount;
             tokenReward.transfer(msg.sender, amount / price);
             FundTransfer(msg.sender, amount, true);


### PR DESCRIPTION
Without the `+`, the `balanceOf` mapping only keeps track of the last purchase an account makes. 

I.e, if an account participates in the crowdsale multiple times, the coin sale fails and an account asks for a refund, the account won't get all of its Ether back.