### PR TITLE
Add link to solidity install instructions

### DIFF
--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -65,7 +65,7 @@ If you have it installed, it should output something like this:
 
     ['Solidity' ]
 
-If you do not get Solidity above, then you need to install it. 
+If you do not get Solidity above, then you need to install it. You can find [instructions for installing Solidity here](http://solidity.readthedocs.io/en/develop/installing-solidity.html).
 
 
 


### PR DESCRIPTION
At this point in the tutorial it is likely that the reader does not have solidity installed, so it probably makes sense to link to where/how to install it. I've included one link I found but if there is a better link that could be included as well. It seems other parts of this page may be out of date but this sentence should help.