### PR TITLE
Update how much space the main blockchain takes up

### DIFF
--- a/views/mixins/recipes.jade
+++ b/views/mixins/recipes.jade
@@ -37,7 +37,7 @@ mixin gethRecipe(header)
           | Basic coding skills
         li 
           input(type="checkbox") 
-          | 1-2Gb free space for the blockchain
+          | 30Gb free space for the blockchain
 
 
 mixin etherRecipe(header)


### PR DESCRIPTION
The tutorials does not say how to join the testnet, so the default you will join is mainnet and that takes up 26 GB at the moment.

There should be an article that talks about that there is different testnet that you can join. The example in the docs describes that you can make you own tesnet, but does not give you the JSON for the genesis block.