### PR TITLE
Update type signature of `Crowdsale` constructor

### DIFF
--- a/views/content/crowdsale.md
+++ b/views/content/crowdsale.md
@@ -47,7 +47,7 @@ Now copy this code and let's create the crowdsale:
             uint fundingGoalInEthers,
             uint durationInMinutes,
             uint etherCostOfEachToken,
-            token addressOfTokenUsedAsReward
+            address addressOfTokenUsedAsReward
         ) {
             beneficiary = ifSuccessfulSendTo;
             fundingGoal = fundingGoalInEthers * 1 ether;


### PR DESCRIPTION
`addressOfTokenUsedAsReward` should be of type `address` as the name suggests. While solc doesn't complain about the current implementation, I think setting the `address` type conveys the intention better.