### PR TITLE
Update token.md from example on Ethereum.org index page

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -69,7 +69,7 @@ But if you just want to copy paste the code, then use this:
         /* Internal transfer, only can be called by this contract */
         function _transfer(address _from, address _to, uint _value) internal {
             require (_to != 0x0);                               // Prevent transfer to 0x0 address. Use burn() instead
-            require (balanceOf[_from] > _value);                // Check if the sender has enough
+            require (balanceOf[_from] >= _value);                // Check if the sender has enough
             require (balanceOf[_to] + _value > balanceOf[_to]); // Check for overflows
             balanceOf[_from] -= _value;                         // Subtract from the sender
             balanceOf[_to] += _value;                            // Add the same to the recipient


### PR DESCRIPTION
It is impossible to send all balance because of > is bug, at least 0.0000001 part (or so) will stay at old wallet and lost.
Need to use >= instead of course.
Possible problems with payments and automatization, as sending all amount will cause errors.
For example Hubcoin deposits / withdraws at https://etherscan.io/address/0x563383b56367Ff2afFFE5c6BCF9187bBE52d40Ad Hubcoin contract was failed on CoinExchange.io because of it bug.