### PR TITLE
Align left on mobile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1637,19 +1637,10 @@ footer {
 	}
 }
 
-@media only screen and (max-width: 600px ) {
-	.row {
-		text-align: center;
-	}
-
-	.row .recipe , code {
-		text-align: left;
-	}
-
+@media only screen and (max-width: 600px) {
 	figure {
 		height: 300px;
 		margin: 0 auto;
-
 	}
 
 	.main-tutorial a.button ,


### PR DESCRIPTION
Browsing ethereum.org on mobile, I noticed a lot of funky center aligns.

I checked the css and there is a global .row{text-align:center;} on screens <600px.

This PR is a suggestion to remove that in favor of staying default left aligned.

Screenshots before/after:
<img width="310" alt="screen shot 2017-09-13 at 9 30 27 am" src="https://user-images.githubusercontent.com/22116/30389993-81c114ae-9869-11e7-913a-1e6253a5ea5b.png"><img width="297" alt="screen shot 2017-09-13 at 9 30 32 am" src="https://user-images.githubusercontent.com/22116/30389992-81bf6492-9869-11e7-9d87-c86b84d34317.png">

<img width="316" alt="screen shot 2017-09-13 at 9 31 05 am" src="https://user-images.githubusercontent.com/22116/30390004-8547e364-9869-11e7-9c7e-47d16410d108.png"><img width="313" alt="screen shot 2017-09-13 at 9 31 10 am" src="https://user-images.githubusercontent.com/22116/30390005-854a0b08-9869-11e7-8e57-77d10a01e54e.png">

<img width="312" alt="screen shot 2017-09-13 at 9 31 30 am" src="https://user-images.githubusercontent.com/22116/30390009-895c27d0-9869-11e7-928e-b8cfe9153ebf.png"><img width="316" alt="screen shot 2017-09-13 at 9 32 10 am" src="https://user-images.githubusercontent.com/22116/30390010-8963abb8-9869-11e7-82c0-11d56bff0d9a.png">

