### PR TITLE
Update CSS/JS file names to remove frontier reference

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,8 +38,8 @@ module.exports = function(grunt) {
 		},
 		clean: {
 			build: ['dist'],
-			cleanup_js: ['dist/js/*.*', '!dist/js/frontier.*'],
-			cleanup_css: ['dist/css/*.css', '!dist/css/frontier.*.css']
+			cleanup_js: ['dist/js/*.*', '!dist/js/app.*'],
+			cleanup_css: ['dist/css/*.css', '!dist/css/app.*.css']
 		},
 		jade: {
 			build: {
@@ -198,16 +198,16 @@ module.exports = function(grunt) {
 				src: app,
 				dest: 'dist/js/app.js'
 			},
-			frontier: {
+			js: {
 				options: {
 					sourceMap: true
 				},
 				src: ['<%= uglify.vendor.dest %>', '<%= uglify.app.dest %>'],
-				dest: 'dist/js/frontier.min.js'
+				dest: 'dist/js/app.min.js'
 			},
 			css: {
 				src: ['dist/css/*.min.css', 'dist/css/*.css'],
-				dest: 'dist/css/frontier.min.css'
+				dest: 'dist/css/app.min.css'
 			}
 		},
 		uglify: {
@@ -233,6 +233,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-http');
 
-	grunt.registerTask('default', ['http', 'clean', 'jade', 'copy', 'cssmin', 'concat:vendor', 'concat:app', 'uglify', 'concat:frontier', 'concat:css', 'clean:cleanup_js', 'clean:cleanup_css']);
+	grunt.registerTask('default', ['http', 'clean', 'jade', 'copy', 'cssmin', 'concat:vendor', 'concat:app', 'uglify', 'concat:js', 'concat:css', 'clean:cleanup_js', 'clean:cleanup_css']);
 	grunt.registerTask('build', 'default');
 };

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -32,7 +32,7 @@ html
     meta(property="og:description", content="Ethereum is a decentralized platform for applications that run exactly as programmed without any chance of fraud, censorship or third-party interference.")
 
     link(href='//fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,600,900,400italic' rel='stylesheet' type='text/css')
-    link(rel='stylesheet', href='/css/frontier.min.css')
+    link(rel='stylesheet', href='/css/app.min.css')
     link(rel='stylesheet', href='//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/default.min.css')
   body
     include ./includes/head.jade
@@ -41,7 +41,7 @@ html
 
     include ./includes/footer.jade
 
-    script(src="/js/frontier.min.js")
+    script(src="/js/app.min.js")
     script(src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/highlight.min.js")
 
     script


### PR DESCRIPTION
Updated Gruntfile to compile to `app.css` and `app.js` (instead of `frontier.css` and `frontier.js`)