### PR TITLE
Fixes typo: Change ccount to account

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -535,7 +535,7 @@ If you add all the advanced options, this is how the final code should look like
         }
 
         /**
-         * Destroy tokens from other ccount
+         * Destroy tokens from other account
          *
          * Remove `_value` tokens from the system irreversibly on behalf of `_from`.
          *


### PR DESCRIPTION
This commit fixes a typo in the docs located here:

https://ethereum.org/token#proof-of-work

