### PR TITLE
Add word missing to to make grammatically correct.

### DIFF
--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -64,7 +64,7 @@ This process is usually called **_mining_** in the crypto-currency lingo.
 
 If you are on a [private network](../cli) (and if you just want to test the technology for free, you should) then any normal computer with a normal CPU will be able to run the network and earn test ether (ether that is only redeemable on the test network where it was generated) through mining. This is the best choice for small scale network or testing privately, as it's less resource intensive. On the real (or live test) network a normal desktop (or laptop) computer might take a very long time to successfully mine a block and receive ether.
 
-Before you do any mining, you need to set which address will receive your earnings (called "etherbase"). You only need to this once. Here's how to set your etherbase and then start mining:
+Before you do any mining, you need to set which address will receive your earnings (called "etherbase"). You only need to do this once. Here's how to set your etherbase and then start mining:
 
 **Geth:**
 


### PR DESCRIPTION
In the section "CPU MINING USING THE COMMAND LINE"

it read: "You only need to this once."

Updated to read: "You only need to do this once."