### PR TITLE
Updated "event GoalReached" parameters labels to avoid compile error

### DIFF
--- a/solidity/crowdsale.sol
+++ b/solidity/crowdsale.sol
@@ -16,7 +16,7 @@ contract Crowdsale {
     bool fundingGoalReached = false;
     bool crowdsaleClosed = false;
 
-    event GoalReached(address beneficiary, uint amountRaised);
+    event GoalReached(address recipient, uint totalAmountRaised);
     event FundTransfer(address backer, uint amount, bool isContribution);
 
     /**


### PR DESCRIPTION
Was getting a compile error as `This declaration shadows an existing declaration`.
hence, changed 
`event GoalReached(address beneficiary, uint amountRaised);` 
to 
`event GoalReached(address recipient, uint totalAmountRaised);`