### PR TITLE
Updating deprecated .send(...) to .transfer(...)

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -317,7 +317,7 @@ The next step is making the buy and sell functions:
         balanceOf[this] += amount;                        // adds the amount to owner's balance
         balanceOf[msg.sender] -= amount;                  // subtracts the amount from seller's balance
         revenue = amount * sellPrice;
-        require(msg.sender.send(revenue));                // sends ether to the seller: it's important to do this last to prevent recursion attacks
+        msg.sender.transfer(revenue);                     // sends ether to the seller: it's important to do this last to prevent recursion attacks
         Transfer(msg.sender, this, amount);               // executes an event reflecting on the change
         return revenue;                                   // ends function and returns
     }


### PR DESCRIPTION
.send(...) is now deprecated.
Send vs transfer comparsion:
https://vomtom.at/solidity-send-vs-transfer/
Also the Solidity by Example Documentation got updated and now uses the .transfer() function.
http://solidity.readthedocs.io/en/develop/solidity-by-example.html
We dont need to use require, as transfer fully propagates errors.