### PR TITLE
Fix foundation page broken link

### DIFF
--- a/dist/foundation.html
+++ b/dist/foundation.html
@@ -10,7 +10,7 @@
 <h4>Vitalik Buterin</h4>
 <p><img src="/images/portraits/vitalik-buterin.jpg" alt="Portrait of Vitalik Buterin"></p>
 <p><strong>Vitalik is the creator of Ethereum.</strong> He first discovered blockchain and cryptocurrency technologies through Bitcoin in 2011, and was immediately excited by the technology and its potential. He cofounded Bitcoin Magazine in September 2011, and after two and a half years looking at what the existing blockchain technology and applications had to offer, wrote the Ethereum white paper in November 2013. He now leads Ethereum's research team, working on future versions of the Ethereum protocol.</p>
-<p><a href="https://www.vitalik.ca">Website</a>, <a href="https://twitter.com/vitalikbuterin">Twitter</a>, <a href="https://github.com/vbuterin/">GitHub</a></p>
+<p><a href="http://www.vitalik.ca">Website</a>, <a href="https://twitter.com/vitalikbuterin">Twitter</a>, <a href="https://github.com/vbuterin/">GitHub</a></p>
 <hr>
 <h3>Technical Steering Group</h3>
 <h4>Jeffrey Wilcke</h4>

--- a/views/content/foundation.md
+++ b/views/content/foundation.md
@@ -22,7 +22,7 @@
 
 **Vitalik is the creator of Ethereum.** He first discovered blockchain and cryptocurrency technologies through Bitcoin in 2011, and was immediately excited by the technology and its potential. He cofounded Bitcoin Magazine in September 2011, and after two and a half years looking at what the existing blockchain technology and applications had to offer, wrote the Ethereum white paper in November 2013. He now leads Ethereum's research team, working on future versions of the Ethereum protocol.
 
-[Website](https://www.vitalik.ca), [Twitter](https://twitter.com/vitalikbuterin), [GitHub](https://github.com/vbuterin/)
+[Website](http://www.vitalik.ca), [Twitter](https://twitter.com/vitalikbuterin), [GitHub](https://github.com/vbuterin/)
 
 ----
 


### PR DESCRIPTION
Note: https://www.vitalik.ca currently returns 500 Error. This might be a temporary issue. I changed the link to http://www.vitalik.ca which works.