### PR TITLE
Add error handling to Greeter tutorial

### DIFF
--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -106,7 +106,9 @@ You have now compiled your code and made it available to Geth.  Now you need to 
             console.log(contract);
           }
 
-        }
+        } else {
+	  console.error(e); // If something goes wrong, at least we'll know.
+	}
     })
 
 

--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -96,19 +96,18 @@ You have now compiled your code and made it available to Geth.  Now you need to 
 	var _greeting = "Hello World!"
 
     var greeter = greeterFactory.new(_greeting,{from:eth.accounts[0],data:greeterCompiled,gas:47000000}, function(e, contract){
-        if(!e) {
+        if(e) {
+          console.error(e); // If something goes wrong, at least we'll know.
+          return;
+        }
 
-          if(!contract.address) {
-            console.log("Contract transaction send: TransactionHash: " + contract.transactionHash + " waiting to be mined...");
-
-          } else {
-            console.log("Contract mined! Address: " + contract.address);
-            console.log(contract);
-          }
+        if(!contract.address) {
+          console.log("Contract transaction send: TransactionHash: " + contract.transactionHash + " waiting to be mined...");
 
         } else {
-	  console.error(e); // If something goes wrong, at least we'll know.
-	}
+          console.log("Contract mined! Address: " + contract.address);
+          console.log(contract);
+        }
     })
 
 


### PR DESCRIPTION
While trying to get up and running with contract deployment through geth, I spent multiple hours trying to debug the `greeterFactory.new(...)` command in this tutorial without realizing that I was getting an "Error: exceeds block gas limit" error. This change makes it so that the console will log if contract deployment fails.