### PR TITLE
Update Greeter tutorial to comply with change in Remix's UI

### DIFF
--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -55,19 +55,21 @@ You'll notice that there are two different contracts in this code: _"mortal"_ an
 
 The inherited characteristic _"mortal"_ simply means that the greeter contract can be killed by its owner, to clean up the blockchain and recover funds locked into it when the contract is no longer needed. Contracts in ethereum are, by default, immortal and have no owner, meaning that once deployed the author has no special privileges anymore. Consider this before deploying.
 
-### The Solc Compiler
+### Compiling your contract using the Solc Compiler
 
-Before you are able to Deploy it though, you'll need two things: the compiled code, and the Application Binary Interface, which is a JavaScript Object that defines how to interact with the contract.
+Before you are able to deploy your contract, you'll need two things: 
 
-Both of these you can get by using a compiler. You could use the solidity compiler for this.
+1. The compiled code.
+2. The Application Binary Interface, which is a JavaScript Object that defines how to interact with the contract.
 
-If you have not installed a compiler, then you need to install one. You can find [instructions for installing Solidity here](http://solidity.readthedocs.io/en/develop/installing-solidity.html).
+You can get both of these by using a Solidity compiler. If you have not installed a compiler, you can either: 
 
-#### Compiling your contract 
+1. Install a compiler on your machine by following the [instructions for installing the Solidity Compiler](http://solidity.readthedocs.io/en/develop/installing-solidity.html).
+2. Use [Remix](https://remix.ethereum.org), a web-based Solidity IDE.
 
-If you do not get Solidity above, then you need to install it. You can find [instructions for installing Solidity here](http://solidity.readthedocs.io/en/develop/installing-solidity.html).
+#### Solc on your machine
 
-Now you have the compiler installed, you need to compile the contract to acquire the compiled code and Application Binary Interface.
+If you installed the compiler on your machine, you need to compile the contract to acquire the compiled code and Application Binary Interface.
 
     solc -o target --bin --abi Greeter.sol
 
@@ -110,9 +112,9 @@ You have now compiled your code and made it available to Geth.  Now you need to 
     })
 
 
-#### Using the online compiler
+#### Using Remix
 
-If you don't have solC installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://ethereum.github.io/browser-solidity/) and then your compiled code should appear on the left pane. Copy the code in the box labeled **Web3 deploy** for both the `greeter` contract and the `mortal` contract to a single text file. Now, in that file, change the first line to your greeting:
+If you don't have Solc installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://remix.ethereum.org) and then your compiled code should appear on the left pane. Copy the code in the box labeled **Web3 deploy** for both the `greeter` contract and the `mortal` contract to a single text file. Now, in that file, change the first line to your greeting:
 
     var _greeting = "Hello World!"
  

--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -116,7 +116,7 @@ You have now compiled your code and made it available to Geth.  Now you need to 
 
 If you don't have Solc installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://remix.ethereum.org) and it should automatically compile your code. You can safely ignore any yellow warning boxes on the right plane.
 
-To access the compiled code, ensure that the dropdown menu on the right pane has `greeter` selected. Then click on the **Details** button directly to the right of the dropdown. In the popup, scroll down and copy all the code in the **WEB3DEPLOY** box.
+To access the compiled code, ensure that the dropdown menu on the right pane has `greeter` selected. Then click on the **Details** button directly to the right of the dropdown. In the popup, scroll down and copy all the code in the **WEB3DEPLOY** textbox.
 
 Create a temporary text file on your computer and paste that code. Make sure to change the first line to look like the following:
 
@@ -153,12 +153,17 @@ Since this call changes nothing on the blockchain, it returns instantly and with
 
 #### Getting other people to interact with your code
 
-In order for other people to run your contract they need two things: the address where the contract is located and the ABI (Application Binary Interface) which is a sort of user manual, describing the name of its functions and how to call them to your JavaScript console. In order to get each of them run these commands:
+In order for other people to run your contract they need two things: the `Address` where the contract is located and the `ABI` (Application Binary Interface) which is a sort of user manual, describing the name of its functions and how to call them to your JavaScript console.
 
-    greeterCompiled.greeter.info.abiDefinition;
+To get the `Address`, run this command:
+
     greeter.address;
 
-If you compiled with the [browser-based tool](https://ethereum.github.io/browser-solidity/), you can get the ABI from the fields for the `greeter` and `mortal` contracts labeled "Interface".
+To get the `ABI`, run this command:
+
+    greeterCompiled.greeter.info.abiDefinition;
+
+**Tip:** If you compiled the code using [Remix](https://remix.ethereum.org), the last line of code above won't work for you! Instead, you need to copy the `ABI` directly from Remix, similar to how you copied the compiled **WEB3DEPLOY** code. On the right pane, click on the **Details** button and scroll down to the **ABI** textbox. Click on the copy button to copy the entire ABI, then paste it in a temporary text document.
 
 Then you can instantiate a JavaScript object which can be used to call the contract on any machine connected to the network. Replace 'ABI' (an array) and 'Address' (a string) to create a contract object in JavaScript:
 
@@ -169,9 +174,6 @@ This particular example can be instantiated by anyone by simply calling:
     var greeter2 = eth.contract([{constant:false,inputs:[],name:'kill',outputs:[],type:'function'},{constant:true,inputs:[],name:'greet',outputs:[{name:'',type:'string'}],type:'function'},{inputs:[{name:'_greeting',type:'string'}],type:'constructor'}]).at('greeterAddress');
 
 Replace _greeterAddress_ with your contract's address.
-
-
-**Tip: if the solidity compiler isn't properly installed in your machine, you can get the ABI from the online compiler. To do so, use the code below carefully replacing _greeterCompiled.greeter.info.abiDefinition_  with the abi from your compiler.**
 
 
 #### Cleaning up after yourself: 

--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -59,13 +59,13 @@ The inherited characteristic _"mortal"_ simply means that the greeter contract c
 
 Before you are able to deploy your contract, you'll need two things: 
 
-1. The compiled code.
-2. The Application Binary Interface, which is a JavaScript Object that defines how to interact with the contract.
+1. The compiled code
+2. The Application Binary Interface, which is a JavaScript Object that defines how to interact with the contract
 
 You can get both of these by using a Solidity compiler. If you have not installed a compiler, you can either: 
 
-1. Install a compiler on your machine by following the [instructions for installing the Solidity Compiler](http://solidity.readthedocs.io/en/develop/installing-solidity.html).
-2. Use [Remix](https://remix.ethereum.org), a web-based Solidity IDE.
+1. Install a compiler on your machine by following the [instructions for installing the Solidity Compiler](http://solidity.readthedocs.io/en/develop/installing-solidity.html)
+2. Use [Remix](https://remix.ethereum.org), a web-based Solidity IDE
 
 #### Solc on your machine
 
@@ -114,7 +114,7 @@ You have now compiled your code and made it available to Geth.  Now you need to 
 
 #### Using Remix
 
-If you don't have Solc installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://remix.ethereum.org) and it should automatically compile your code. You can safely ignore any yellow warning boxes on the right plane.
+If you don't have Solc installed, you can simply use the online IDE. Copy the source code (at the top of this page) to [Remix](https://remix.ethereum.org) and it should automatically compile your code. You can safely ignore any yellow warning boxes on the right plane.
 
 To access the compiled code, ensure that the dropdown menu on the right pane has `greeter` selected. Then click on the **Details** button directly to the right of the dropdown. In the popup, scroll down and copy all the code in the **WEB3DEPLOY** textbox.
 
@@ -153,7 +153,10 @@ Since this call changes nothing on the blockchain, it returns instantly and with
 
 #### Getting other people to interact with your code
 
-In order for other people to run your contract they need two things: the `Address` where the contract is located and the `ABI` (Application Binary Interface) which is a sort of user manual, describing the name of its functions and how to call them to your JavaScript console.
+In order for other people to run your contract they need two things:
+
+1. The `Address` where the contract is located 
+2. The `ABI` (Application Binary Interface), which is a sort of user manual describing the name of the contract's functions and how to call them to your JavaScript console
 
 To get the `Address`, run this command:
 
@@ -163,9 +166,9 @@ To get the `ABI`, run this command:
 
     greeterCompiled.greeter.info.abiDefinition;
 
-**Tip:** If you compiled the code using [Remix](https://remix.ethereum.org), the last line of code above won't work for you! Instead, you need to copy the `ABI` directly from Remix, similar to how you copied the compiled **WEB3DEPLOY** code. On the right pane, click on the **Details** button and scroll down to the **ABI** textbox. Click on the copy button to copy the entire ABI, then paste it in a temporary text document.
+**Tip:** If you compiled the code using [Remix](https://remix.ethereum.org), the last line of code above won't work for you! Instead, you need to copy the `ABI` directly from Remix, similar to how you copied the **WEB3DEPLOY** compiled code. On the right pane, click on the **Details** button and scroll down to the **ABI** textbox. Click on the copy button to copy the entire ABI, then paste it in a temporary text document.
 
-Then you can instantiate a JavaScript object which can be used to call the contract on any machine connected to the network. Replace 'ABI' (an array) and 'Address' (a string) to create a contract object in JavaScript:
+Then you can instantiate a JavaScript object which can be used to call the contract on any machine connected to the network. In the following line, replace `ABI` (an array) and `Address` (a string) to create a contract object in JavaScript:
 
     var greeter = eth.contract(ABI).at(Address);
 
@@ -173,7 +176,7 @@ This particular example can be instantiated by anyone by simply calling:
 
     var greeter2 = eth.contract([{constant:false,inputs:[],name:'kill',outputs:[],type:'function'},{constant:true,inputs:[],name:'greet',outputs:[{name:'',type:'string'}],type:'function'},{inputs:[{name:'_greeting',type:'string'}],type:'constructor'}]).at('greeterAddress');
 
-Replace _greeterAddress_ with your contract's address.
+Of course, `greeterAddress` must be replaced with your contract's _unique_ address.
 
 
 #### Cleaning up after yourself: 

--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -114,7 +114,11 @@ You have now compiled your code and made it available to Geth.  Now you need to 
 
 #### Using Remix
 
-If you don't have Solc installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://remix.ethereum.org) and then your compiled code should appear on the left pane. Copy the code in the box labeled **Web3 deploy** for both the `greeter` contract and the `mortal` contract to a single text file. Now, in that file, change the first line to your greeting:
+If you don't have Solc installed, you can simply use the online compiler. Copy the source code above to the [online solidity compiler](https://remix.ethereum.org) and it should automatically compile your code. You can safely ignore any yellow warning boxes on the right plane.
+
+To access the compiled code, ensure that the dropdown menu on the right pane has `greeter` selected. Then click on the **Details** button directly to the right of the dropdown. In the popup, scroll down and copy all the code in the **WEB3DEPLOY** box.
+
+Create a temporary text file on your computer and paste that code. Make sure to change the first line to look like the following:
 
     var _greeting = "Hello World!"
  


### PR DESCRIPTION
It seems like the UI for [Remix](https://remix.ethereum.org/) changed since this tutorial was last updated. 

I edited some content so that the instructions match the new UI. The user can now retrieve the `Web3Deploy` compiled code and `ABI` by following the instructions.

I also made it clearer that the user can choose between using Remix or downloading Solc. Last but not least, there are a few formatting changes in those sections.

This is my first pull request to the ethereum project, so I'm not entirely sure how to process works. Let me know if I didn't follow the guidelines!

