### PR TITLE
Add necessary 'public' to function in tutorial

### DIFF
--- a/views/content/token.md
+++ b/views/content/token.md
@@ -50,7 +50,7 @@ Notice that the *function MyToken* has the same name as the *contract MyToken*. 
 The choice of 21 million was rather arbitrary, and you can change it to anything you want in the code, but there's a better way: instead, supply it as a parameter for the function, like this:
 
 ```
-    function MyToken(uint256 initialSupply) {
+    function MyToken(uint256 initialSupply) public {
         balanceOf[msg.sender] = initialSupply;
     }
 ```


### PR DESCRIPTION
Without declaring 'public' on this function, Ethereum Wallet returns the error:

```
No visibility specified. Defaulting to "public".
    function Token(uint256 initialSupply)  {
    ^
Spanning multiple lines.
```

Proposing to add that in so tutorial takers don't run into this error, get confused, etc.
<img width="1354" alt="screen shot 2018-01-17 at 5 34 44 pm" src="https://user-images.githubusercontent.com/6458377/35076342-be81ed9a-fbac-11e7-8e4e-3b17fa0d3435.png">

