### PR TITLE
[admin.nodeInfo.nodeURL] >> [admin.nodeInfo.enode]

### DIFF
--- a/views/content/cli.md
+++ b/views/content/cli.md
@@ -160,7 +160,7 @@ If you want to create a private network you should, for security reasons, use a 
 
 These commands prevent anyone who doesn't know your chosen — secret — nonce, network id and genesis file, from connecting to you or providing you with unwanted data. If you *want* to connect to other peers and create a small private network of multiple computers they will all need to use the same networkid and an identical genesis block. You will also have to help each node find the others. To do that, first you need your own Node URL:
 
-    admin.nodeInfo.NodeUrl
+    admin.nodeInfo.enode
 
 Which will return your node url - make a note of it and then on the other clients, tell them to add your peer by executing this command:
 


### PR DESCRIPTION
The command '**admin.nodeInfo.nodeURL**', results in '**undefined'**, in the recent version of Geth.
_Here is the actual output, based on the recent version of Geth:_

> myMac:console2 admin$ geth attach ipc:../node2/geth.ipc 
> Welcome to the Geth JavaScript console!
> 
> instance: Geth/v1.7.3-stable/darwin-amd64/go1.9.2
> coinbase: 0x3fd97155061e47960b59b563a178fa248493017c
> at block: 2 (Thu, 11 Jan 2018 20:25:58 +04)
>  datadir: /Users/admin/MyXyz/testnet/node2
>  modules: admin:1.0 clique:1.0 debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
> 
> \> web3.eth.accounts
> ["0x3fd97155061e47960b59b563a178fa248493017c"]
> \> admin.nodeInfo.nodeURL
> undefined
> \> admin.nodeInfo.enode
> "enode://f48fcf69ba27442ff3813912ec12ea1ad249f14739dabfcadb3985c3654540e047700030adba5800bf33d0adbdd9ca5f1c47aae2498a0d9dafb8c2fd730969b4@[::]:3002?discport=0"
> \> 
> 