### PR TITLE
Add clickjack prevention

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -7,6 +7,15 @@ html
     meta(http-equiv="X-UA-Compatible",content="chrome=1")
     title= title
 
+    style(id="antiClickjack")
+        | body{display:none !important;}
+    script
+        | if (self === top) {
+        |     var antiClickjack = document.getElementById('antiClickjack');
+        |     antiClickjack.parentNode.removeChild(antiClickjack);
+        | } else {
+        |     top.location = self.location;
+        | }
 
     meta(name="description", content="Ethereum is a decentralized platform for applications that run exactly as programmed without any chance of fraud, censorship or third-party interference.")
 


### PR DESCRIPTION
The current site is open to [clickjack](https://www.owasp.org/index.php/Clickjacking) attacks which could be very serious. You can see this in action with this [simple example](https://cdn.rawgit.com/wrakky/1023c6075b6154324c0310c4f8617a81/raw/8567f8b97e82a68649ba3e45672958a22e07eef0/clickjack.html) I knocked up in less than 10 minutes - scroll down and click the big blue "Download" link, and imagine I've hosted this on ethereom.org or something similar to trick people into thinking it's the real site.

A proper solution would be to serve the correct CSP headers but Github Pages doesn't allow you to do that so this fix adds the recommended alternative from OWASP by use of some frame busting code in the header of every page as a temporary workaround until the headers can be served.

One drawback of this is that it relies on Javascript so anyone with it disabled will no longer be able to use the site. The code can be changed to still allow non-js users to access it if required but then they will still be vulnerable to the clickjacking.