### PR TITLE
Link to wiki

### DIFF
--- a/views/includes/footer.pug
+++ b/views/includes/footer.pug
@@ -76,7 +76,7 @@ footer.scrollme
                 li Browse our source code on 
                   a(href='https://github.com/ethereum/', target='_blank') GitHub
                 li Read the   
-                  a(href='http://www.ethdocs.org/', target='_blank') documentation
+                  a(href='http://www.ethdocs.org/', target='_blank') documentation or a(href='https://github.com/ethereum/wiki/wiki', target='_blank') wiki
                 li Learn  
                   a(href='https://solidity.readthedocs.org/', target='_blank') Solidity
                 li See the latest 

--- a/views/includes/footer.pug
+++ b/views/includes/footer.pug
@@ -75,9 +75,11 @@ footer.scrollme
                   a(href='./ether') Read our FAQ
                 li Browse our source code on 
                   a(href='https://github.com/ethereum/', target='_blank') GitHub
-                li Read the   
-                  a(href='http://www.ethdocs.org/', target='_blank') documentation or a(href='https://github.com/ethereum/wiki/wiki', target='_blank') wiki
-                li Learn  
+                li Read the 
+                  a(href='http://www.ethdocs.org/', target='_blank') documentation
+                  or 
+                  a(href='https://github.com/ethereum/wiki/wiki', target='_blank') wiki
+                li Learn 
                   a(href='https://solidity.readthedocs.org/', target='_blank') Solidity
                 li See the latest 
                   a(href='https://ethstats.net', target='_blank') data and network stats


### PR DESCRIPTION
https://github.com/ethereum/wiki/wiki contains a wealth of information, that is frequently updated, from an introductory level to advanced. Thus, it would be good to link to it on the website.