### PR TITLE
Transfer of zero ERC20 Token must success

### DIFF
--- a/solidity/token-advanced.sol
+++ b/solidity/token-advanced.sol
@@ -194,7 +194,7 @@ contract MyAdvancedToken is owned, TokenERC20 {
     function _transfer(address _from, address _to, uint _value) internal {
         require (_to != 0x0);                               // Prevent transfer to 0x0 address. Use burn() instead
         require (balanceOf[_from] >= _value);               // Check if the sender has enough
-        require (balanceOf[_to] + _value > balanceOf[_to]); // Check for overflows
+        require (balanceOf[_to] + _value >= balanceOf[_to]); // Check for overflows
         require(!frozenAccount[_from]);                     // Check if sender is frozen
         require(!frozenAccount[_to]);                       // Check if recipient is frozen
         balanceOf[_from] -= _value;                         // Subtract from the sender

--- a/solidity/token-erc20.sol
+++ b/solidity/token-erc20.sol
@@ -45,7 +45,7 @@ contract TokenERC20 {
         // Check if the sender has enough
         require(balanceOf[_from] >= _value);
         // Check for overflows
-        require(balanceOf[_to] + _value > balanceOf[_to]);
+        require(balanceOf[_to] + _value >= balanceOf[_to]);
         // Save this for an assertion in the future
         uint previousBalances = balanceOf[_from] + balanceOf[_to];
         // Subtract from the sender

--- a/views/content/token.md
+++ b/views/content/token.md
@@ -163,7 +163,7 @@ Because many of these functions are having to reimplement the transferring of to
     function _transfer(address _from, address _to, uint _value) internal {
         require (_to != 0x0);                               // Prevent transfer to 0x0 address. Use burn() instead
         require (balanceOf[_from] >= _value);                // Check if the sender has enough
-        require (balanceOf[_to] + _value > balanceOf[_to]); // Check for overflows
+        require (balanceOf[_to] + _value >= balanceOf[_to]); // Check for overflows
         require(!frozenAccount[_from]);                     // Check if sender is frozen
         require(!frozenAccount[_to]);                       // Check if recipient is frozen
         balanceOf[_from] -= _value;                         // Subtract from the sender


### PR DESCRIPTION
Hi,
as an exercice to learn how to use Truffle, I'm developping an ERC20 token test suite.
I realised that the ERC20 token on ethereum.org does not comply with the ERC20 token standard <:o)  !!!

If you look at the ERC20  token standard, here:
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#transfer
You can read that:
Transfers of 0 values MUST be treated as normal transfers and fire the Transfer event.

But in  the example, you are too strict when checking for overflows. A 0 token transaction will revert.
I think we need to change the > into >= to allow successful transfers of 0 token as required by the standard.