### PR TITLE
Revert #792

### DIFF
--- a/views/content/greeter.md
+++ b/views/content/greeter.md
@@ -59,7 +59,6 @@ The inherited characteristic _"mortal"_ simply means that the greeter contract c
 
 Before you are able to deploy your contract, you'll need two things: 
 
-
 1. The compiled code
 2. The Application Binary Interface, which is a JavaScript Object that defines how to interact with the contract
 
@@ -72,7 +71,6 @@ You can get both of these by using a Solidity compiler. If you have not installe
 #### Solc on your machine
 =======
 
-Now you have the compiler installed, you need to compile the contract to acquire the compiled code and Application Binary Interface.
 
 If you installed the compiler on your machine, you need to compile the contract to acquire the compiled code and Application Binary Interface.
 
@@ -116,7 +114,6 @@ You have now compiled your code and made it available to Geth.  Now you need to 
           console.log(contract);
         }
     })
-
 
 
 #### Using Remix


### PR DESCRIPTION
Reverts ethereum/ethereum-org#792

The changes in pull request #792 don't make much sense. The one line of documentation that was added conflicts with the line right below it, so I have a feeling this was done by accident.

Looking at the commits in #792, it seems like there are a ton of changes that didn't get merged in. Perhaps the commits were not merged correctly?