### PR TITLE
Removed horizontal overflow generated by figures on mobile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -564,6 +564,10 @@ div.scrollme.row.introduction {
 		margin: 30px auto;
 	}
 
+	figure {
+		max-width: calc(100% - 30px);
+	}
+
 	.inner-header .scrollme {
 	    display: block;
 	}


### PR DESCRIPTION
Addresses issue #819 

The reason for -30px is because of the margins generated by bootstraps __.row__ class which has -15px margin left and -15px margin right.

It only applies to screens with max-width: 800px