### PR TITLE
make transfer func compatible to eip20 standard

### DIFF
--- a/solidity/token-advanced.sol
+++ b/solidity/token-advanced.sol
@@ -82,8 +82,9 @@ contract TokenERC20 {
      * @param _to The address of the recipient
      * @param _value the amount to send
      */
-    function transfer(address _to, uint256 _value) public {
+    function transfer(address _to, uint256 _value) public returns (bool success) {
         _transfer(msg.sender, _to, _value);
+        return true;
     }
 
     /**


### PR DESCRIPTION
As discussed in https://github.com/ethereum/solidity/issues/4116
Due to solidity compiler change after v0.4.22, this wrong transfer function will cause serious issues.
We (SECBIT.IO) found many people followed this tutorial on ethereum.org.
SHOULD fix this ASAP!