### PR TITLE
Fixing wiki link spacing on footer

### DIFF
--- a/views/includes/footer.pug
+++ b/views/includes/footer.pug
@@ -73,7 +73,8 @@ footer.scrollme
                   a(href='https://github.com/ethereum/', target='_blank') GitHub
                 li Read the 
                   a(href='http://www.ethdocs.org/', target='_blank') documentation
-                  or 
+                  |
+                  | or 
                   a(href='https://github.com/ethereum/wiki/wiki', target='_blank') wiki
                 li Learn 
                   a(href='https://solidity.readthedocs.org/', target='_blank') Solidity


### PR DESCRIPTION
From: 
<img width="385" alt="screen shot 2018-06-07 at 12 28 39 pm" src="https://user-images.githubusercontent.com/47108/41109844-5a17b090-6a4e-11e8-9a96-f53460727c56.png">

To:
<img width="386" alt="screen shot 2018-06-07 at 12 25 10 pm" src="https://user-images.githubusercontent.com/47108/41109845-5a403394-6a4e-11e8-93db-286824935f5d.png">
