### PR TITLE
fix a glaring bug in removeMember

### DIFF
--- a/views/content/dao-congress.sol
+++ b/views/content/dao-congress.sol
@@ -130,7 +130,9 @@ interface Token {
 
         for (uint i = memberId[targetMember]; i<members.length-1; i++){
             members[i] = members[i+1];
+            memberId[members[i].member] = i;
         }
+        memberId[targetMember] = 0;
         delete members[members.length-1];
         members.length--;
     }


### PR DESCRIPTION
removeMember needs to tidy up the memberId mappings, else the whole member system will break upon calling removeMember