### PR TITLE
Fix formatting error in "who needs ether"

### DIFF
--- a/views/content/ether.md
+++ b/views/content/ether.md
@@ -19,7 +19,8 @@ But the rate is not expected to be kept: sometime in 2018-2019 Ethereum will be 
 
 ### Who needs ether?
 
-Developers who intend to build apps that will use the ethereum blockchain. Users who want to access and interact with smart contracts on the ethereum blockchain.
++ Developers who intend to build apps that will use the ethereum blockchain. 
++ Users who want to access and interact with smart contracts on the ethereum blockchain.
 
 
 ### I bought ether during the 2014 presale. How do I access it?


### PR DESCRIPTION
The "who needs ether" section was phrased strangely, they should either have been put into bullet points, or turned into a single sentence. If you try to put it into a single sentence, it leads to the odd repetition of "and" in the same sentence. I decided to use bullet points, even though it might have been overkill for just 2 items.

Either way works, but the original certainly doesn't read right.